### PR TITLE
LineBotClientBuilder

### DIFF
--- a/line-bot-api-client/README.md
+++ b/line-bot-api-client/README.md
@@ -4,11 +4,10 @@ LINE bot API client for Java 8.
 
 ## SYNOPSIS
 
-        DefaultLineBotClient defaultLineBotClient = new DefaultLineBotClient(
-                "YOUR_CHANNEL_ID",
-                "YOUR_CHANNEL_SECRET",
-                "YOUR_CHANNEL_MID");
-        defaultLineBotClient.sendText("USER_MID", "Hello");
+        LineBotClient client = LineBotClientBuilder
+                .create("YOUR_CHANNEL_ID", "YOUR_CHANNEL_SECRET", "YOUR_CHANNEL_MID")
+                .build();
+        client.sendText("USER_MID", "Hello");
 
 ## DESCRIPTION
 

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/DefaultLineBotClient.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/DefaultLineBotClient.java
@@ -84,6 +84,30 @@ public class DefaultLineBotClient implements LineBotClient {
 
     public static final String DEFAULT_SENDING_MULTIPLE_MESSAGES_EVENT_ID = "140177271400161403";
 
+    private static final String DEFAULT_USER_AGENT =
+            "line-botsdk-java/" + DefaultLineBotClient.class.getPackage().getImplementationVersion();
+
+    private static ObjectMapper buildDefaultObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return objectMapper;
+    }
+
+    private static HttpClientBuilder buildDfaultHttpClientBuilder() {
+        RequestConfig requestConfig = RequestConfig
+                .custom()
+                .setConnectTimeout(3000)
+                .setConnectionRequestTimeout(3000)
+                .setSocketTimeout(3000)
+                .build();
+
+        return HttpClientBuilder
+                .create()
+                .disableAutomaticRetries()
+                .setDefaultRequestConfig(requestConfig)
+                .setUserAgent(DEFAULT_USER_AGENT);
+    }
+
     private final String channelId;
     private final String channelSecret;
     private final String channelMid;
@@ -96,96 +120,38 @@ public class DefaultLineBotClient implements LineBotClient {
     private final ObjectMapper objectMapper;
     private final HttpClientBuilder httpClientBuilder;
 
-    // For testing.
-    public DefaultLineBotClient(
-            String channelId,
-            String channelSecret,
-            String channelMid,
-
-            String apiEndPoint,
-
-            Long sendingMessageChannelId,
-            String sendingMessageEventId,
-            String sendingMultipleMessagesEventId,
-
-            ObjectMapper objectMapper,
-            HttpClientBuilder httpClientBuilder) {
-        this.channelId = channelId;
-        this.channelSecret = channelSecret;
-        this.channelMid = channelMid;
-
-        this.apiEndPoint = apiEndPoint;
-
-        this.sendingMessageChannelId = sendingMessageChannelId;
-        this.sendingMessageEventId = sendingMessageEventId;
-        this.sendingMultipleMessagesEventId = sendingMultipleMessagesEventId;
-
-        this.objectMapper = objectMapper;
-        this.httpClientBuilder = httpClientBuilder;
-    }
-
     /**
      * Create new instance.
      *
      * @param channelId Channel ID
      * @param channelSecret Channel secret
      * @param channelMid Channel MID
+     * @param apiEndPoint LINE Bot API endpoint URI
+     * @param sendingMessageChannelId The channel ID to send a message
+     * @param sendingMessageEventId The event type of sending single message
+     * @param sendingMultipleMessagesEventId The event type of sending multiple messages
      * @param objectMapper Instance of Jackson
      * @param httpClientBuilder Instance of Apache HttpClient
      */
-    public DefaultLineBotClient(
+    DefaultLineBotClient(
             String channelId,
             String channelSecret,
             String channelMid,
+            String apiEndPoint,
+            Long sendingMessageChannelId,
+            String sendingMessageEventId,
+            String sendingMultipleMessagesEventId,
             ObjectMapper objectMapper,
-            HttpClientBuilder httpClientBuilder
-    ) {
-        this(channelId, channelSecret, channelMid,
-             DEFAULT_API_END_POINT,
-             DEFAULT_SENDING_MESSAGE_CHANNEL_ID,
-             DEFAULT_SENDING_MESSAGE_EVENT_ID,
-             DEFAULT_SENDING_MULTIPLE_MESSAGES_EVENT_ID,
-             objectMapper, httpClientBuilder);
-    }
-
-    /**
-     * Create new instance
-     *
-     * @param channelId Channel ID
-     * @param channelSecret Channel secret
-     * @param channelMid Channel MID
-     */
-    public DefaultLineBotClient(
-            String channelId,
-            String channelSecret,
-            String channelMid
-    ) {
-        this(channelId, channelSecret, channelMid, buildObjectMapper(), buildHttpClientBuilder());
-    }
-
-    private static ObjectMapper buildObjectMapper() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        return objectMapper;
-    }
-
-    private static HttpClientBuilder buildHttpClientBuilder() {
-        RequestConfig requestConfig = RequestConfig
-                .custom()
-                .setConnectTimeout(3000)
-                .setConnectionRequestTimeout(3000)
-                .setSocketTimeout(3000)
-                .build();
-
-        return HttpClientBuilder
-                .create()
-                .disableAutomaticRetries()
-                .setDefaultRequestConfig(requestConfig)
-                .setUserAgent(buildUserAgent());
-    }
-
-    private static String buildUserAgent() {
-        return "line-botsdk-java/" + DefaultLineBotClient.class.getPackage().getImplementationVersion();
+            HttpClientBuilder httpClientBuilder) {
+        this.channelId = channelId;
+        this.channelSecret = channelSecret;
+        this.channelMid = channelMid;
+        this.apiEndPoint = apiEndPoint;
+        this.sendingMessageChannelId = sendingMessageChannelId;
+        this.sendingMessageEventId = sendingMessageEventId;
+        this.sendingMultipleMessagesEventId = sendingMultipleMessagesEventId;
+        this.objectMapper = objectMapper != null ? objectMapper : buildDefaultObjectMapper();
+        this.httpClientBuilder = httpClientBuilder != null ? httpClientBuilder : buildDfaultHttpClientBuilder();
     }
 
     @Override

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineBotClientBuilder.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineBotClientBuilder.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.NonNull;
+
+/**
+ * A builder that creates a {@link LineBotClient}.
+ * <pre>{@code
+ * // Simple usage
+ * LineBotClient client = LineBotClientBuilder
+ *                          .create("YOUR_CHANNEL_ID", "YOUR_CHANNEL_SECRET", "YOUR_CHANNEL_MID")
+ *                          .objectMapper(yourObjectMapper) // optional
+ *                          .httpClientBuilder(yourHttpClientBuilder) // optional
+ *                          .build();
+ * }</pre>
+ */
+public final class LineBotClientBuilder {
+
+    /**
+     * Create a new {@link LineBotClientBuilder} with specified channel information.
+     */
+    public static LineBotClientBuilder create(String channelId, String channelSecret, String channelMid) {
+        return new LineBotClientBuilder(channelId, channelSecret, channelMid);
+    }
+
+    private final String channelId;
+
+    private final String channelSecret;
+
+    private final String channelMid;
+
+    private String apiEndPoint = DefaultLineBotClient.DEFAULT_API_END_POINT;
+
+    private Long sendingMessageChannelId = DefaultLineBotClient.DEFAULT_SENDING_MESSAGE_CHANNEL_ID;
+
+    private String sendingMessageEventId = DefaultLineBotClient.DEFAULT_SENDING_MESSAGE_EVENT_ID;
+
+    private String sendingMultipleMessagesEventId =
+            DefaultLineBotClient.DEFAULT_SENDING_MULTIPLE_MESSAGES_EVENT_ID;
+
+    private ObjectMapper objectMapper;
+
+    private HttpClientBuilder httpClientBuilder;
+
+    private LineBotClientBuilder(@NonNull String channelId,
+                                 @NonNull String channelSecret,
+                                 @NonNull String channelMid) {
+        this.channelId = channelId;
+        this.channelSecret = channelSecret;
+        this.channelMid = channelMid;
+    }
+
+    /**
+     * Sets the LINE Bot API endpoint uri.
+     */
+    public LineBotClientBuilder apiEndPoint(@NonNull String apiEndPoint) {
+        this.apiEndPoint = apiEndPoint;
+        return this;
+    }
+
+    /**
+     * Sets the object mapper to be used.
+     */
+    public LineBotClientBuilder objectMapper(@NonNull ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        return this;
+    }
+
+    /**
+     * Sets the http client builder to be used.
+     */
+    public LineBotClientBuilder httpClientBuilder(@NonNull HttpClientBuilder httpClientBuilder) {
+        this.httpClientBuilder = httpClientBuilder;
+        return this;
+    }
+
+    /**
+     * Sets the channel id to send a message.
+     */
+    public LineBotClientBuilder sendingMessageChannelId(long sendingMessageChannelId) {
+        this.sendingMessageChannelId = sendingMessageChannelId;
+        return this;
+    }
+
+    /**
+     * Sets the event type to send a single message.
+     */
+    public LineBotClientBuilder sendingMessageEventId(@NonNull String sendingMessageEventId) {
+        this.sendingMessageEventId = sendingMessageEventId;
+        return this;
+    }
+
+    /**
+     * Sets the event type to send multiple messages.
+     */
+    public LineBotClientBuilder sendingMultipleMessagesEventId(@NonNull String sendingMultipleMessagesEventId) {
+        this.sendingMultipleMessagesEventId = sendingMultipleMessagesEventId;
+        return this;
+    }
+
+    /**
+     * Creates a new {@link LineBotClient}.
+     */
+    public LineBotClient build() {
+        return new DefaultLineBotClient(
+                channelId,
+                channelSecret,
+                channelMid,
+                apiEndPoint,
+                sendingMessageChannelId,
+                sendingMessageEventId,
+                sendingMultipleMessagesEventId,
+                objectMapper,
+                httpClientBuilder
+        );
+    }
+}

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotAutoConfiguration.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotAutoConfiguration.java
@@ -29,8 +29,8 @@ import org.springframework.context.annotation.Configuration;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import com.linecorp.bot.client.DefaultLineBotClient;
 import com.linecorp.bot.client.LineBotClient;
+import com.linecorp.bot.client.LineBotClientBuilder;
 import com.linecorp.bot.servlet.LineBotCallbackRequestParser;
 import com.linecorp.bot.spring.boot.interceptor.LineBotServerInterceptor;
 import com.linecorp.bot.spring.boot.support.LineBotServerArgumentProcessor;
@@ -60,15 +60,17 @@ public class LineBotAutoConfiguration {
 
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-        return new DefaultLineBotClient(
-                lineBotProperties.getChannelId(),
-                lineBotProperties.getChannelSecret(),
-                lineBotProperties.getChannelMid(),
-                lineBotProperties.getApiEndPoint(),
-                lineBotProperties.getSendingMessageChannelId(),
-                lineBotProperties.getSendingMessageEventId(),
-                lineBotProperties.getSendingMultipleMessagesEventId(),
-                objectMapper, httpClientBuilder);
+        return LineBotClientBuilder
+                .create(lineBotProperties.getChannelId(),
+                        lineBotProperties.getChannelSecret(),
+                        lineBotProperties.getChannelMid())
+                .apiEndPoint(lineBotProperties.getApiEndPoint())
+                .sendingMessageChannelId(lineBotProperties.getSendingMessageChannelId())
+                .sendingMessageEventId(lineBotProperties.getSendingMessageEventId())
+                .sendingMultipleMessagesEventId(lineBotProperties.getSendingMultipleMessagesEventId())
+                .objectMapper(objectMapper)
+                .httpClientBuilder(httpClientBuilder)
+                .build();
     }
 
     @Bean


### PR DESCRIPTION
In current `DefaultLineBotClient` constructor, A user who want to set a `objectMapper` must also set a `httpClientBuilder` and vice versa.
So It would be convenient if there is a way to create a client using builder pattern.