### PR TITLE
Add `EventType` enum to identify `content` field properly

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/callback/EventType.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/callback/EventType.java
@@ -1,0 +1,27 @@
+package com.linecorp.bot.model.callback;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum EventType {
+
+    Message("138311609000106303"),
+    Operation("138311609100106403");
+
+    private final String value;
+
+    EventType(String value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static EventType of(String value) {
+        for (EventType eventType : values()) {
+            if (Objects.equals(eventType.value, value)) {
+                return eventType;
+            }
+        }
+        throw new IllegalArgumentException("Invalid EventType: " + value);
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/callback/Message.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/callback/Message.java
@@ -40,7 +40,7 @@ public class Message {
     @Getter
     private final List<String> to;
     @Getter
-    private final String eventType;
+    private final EventType eventType;
     @Getter
     private final String id;
     @Getter
@@ -50,7 +50,7 @@ public class Message {
     public Message(
             @JsonProperty("fromChannel") String fromChannel,
             @JsonProperty("to") List<String> to,
-            @JsonProperty("eventType") String eventType,
+            @JsonProperty("eventType") EventType eventType,
             @JsonProperty("id") String id,
             @JsonProperty("content") JsonNode content
     ) {
@@ -63,11 +63,13 @@ public class Message {
 
     // TODO remove this.
     public void parseContent(ObjectMapper objectMapper) throws JsonProcessingException {
-        JsonNode opTypeNode = contentNode.get("opType");
-        if (opTypeNode != null && opTypeNode.isInt()) {
-            this.content = objectMapper.treeToValue(contentNode, AbstractOperation.class);
-        } else {
-            this.content = objectMapper.treeToValue(contentNode, AbstractContent.class);
+        switch (eventType) {
+            case Operation:
+                this.content = objectMapper.treeToValue(contentNode, AbstractOperation.class);
+                break;
+            default:
+                this.content = objectMapper.treeToValue(contentNode, AbstractContent.class);
+                break;
         }
     }
 }

--- a/line-bot-model/src/test/resources/added_as_friend.json
+++ b/line-bot-model/src/test/resources/added_as_friend.json
@@ -7,7 +7,7 @@
         "u0cc15697597f61dd8b01cea8b027050e"
       ],
       "toChannel": 1441301333,
-      "eventType": "138311609000106303",
+      "eventType": "138311609100106403",
       "id": "ABCDEF-12345678901",
       "content": {
         "opType":4,

--- a/line-bot-model/src/test/resources/blocked.json
+++ b/line-bot-model/src/test/resources/blocked.json
@@ -7,7 +7,7 @@
         "u0cc15697597f61dd8b01cea8b027050e"
       ],
       "toChannel": 1441301333,
-      "eventType": "138311609000106303",
+      "eventType": "138311609100106403",
       "id": "ABCDEF-12345678901",
       "content": {
         "opType":8,

--- a/line-bot-servlet/src/test/java/com/linecorp/bot/servlet/LineBotCallbackRequestParserTest.java
+++ b/line-bot-servlet/src/test/java/com/linecorp/bot/servlet/LineBotCallbackRequestParserTest.java
@@ -104,11 +104,13 @@ public class LineBotCallbackRequestParserTest {
 
     @Test
     public void testCallRequest() throws Exception {
+        final String requestBody = "{\"result\":[{\"eventType\":\"138311609000106303\"}]}";
+
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader(LineBotAPIHeaders.X_LINE_CHANNEL_SIGNATURE, "SSSSIGNATURE");
-        request.setContent("{\"result\":[{}]}".getBytes(StandardCharsets.UTF_8));
+        request.setContent(requestBody.getBytes(StandardCharsets.UTF_8));
 
-        when(lineBotClient.validateSignature("{\"result\":[{}]}", "SSSSIGNATURE"))
+        when(lineBotClient.validateSignature(requestBody, "SSSSIGNATURE"))
                 .thenReturn(true);
 
         CallbackRequest callbackRequest = lineBotCallbackRequestParser.handle(


### PR DESCRIPTION
The docment says we can identify the type of `content` by `eventType` field.
https://developers.line.me/bot-api/getting-started-with-bot-api-trial