### PR TITLE
Refactoring RichMessage API

### DIFF
--- a/line-bot-api-client/build.gradle
+++ b/line-bot-api-client/build.gradle
@@ -34,4 +34,5 @@ dependencies {
     optional "org.projectlombok:lombok:1.16.8"
 
     testCompile 'junit:junit:4.11'
+    testCompile 'org.hamcrest:hamcrest-library:1.3'
 }

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/rich/SimpleRichMessageBuilder.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/rich/SimpleRichMessageBuilder.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client.rich;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.linecorp.bot.model.rich.RichMessage;
+import com.linecorp.bot.model.rich.RichMessageImage;
+import com.linecorp.bot.model.rich.RichMessageScene;
+import com.linecorp.bot.model.rich.RichMessageSceneImage;
+import com.linecorp.bot.model.rich.RichMessageSceneListener;
+import com.linecorp.bot.model.rich.action.AbstractRichMessageAction;
+import com.linecorp.bot.model.rich.action.SendMessageRichMessageAction;
+import com.linecorp.bot.model.rich.action.WebRichMessageAction;
+
+import lombok.NonNull;
+
+/**
+ * A builder that creates a RichMessage with single scene+image and multi actions.
+ */
+public final class SimpleRichMessageBuilder {
+
+    private static final String DEFAULT_SCENE_NAME = "scene1";
+
+    private static final String DEFAULT_IMAGE_NAME = "image1";
+
+    /**
+     * Creates a new builder with the specified base canvas size
+     */
+    public static SimpleRichMessageBuilder create(int width, int height) {
+        return new SimpleRichMessageBuilder(width, height);
+    }
+
+    private final int width;
+    private final int height;
+
+    private final List<ActionEntry> actions = new ArrayList<>(5);
+
+    private SimpleRichMessageBuilder(int width, int height) {
+        this.width = width;
+        this.height = height;
+    }
+
+    public SimpleRichMessageBuilder addAction(int x, int y, int width, int height,
+                                              @NonNull AbstractRichMessageAction action) {
+        actions.add(new ActionEntry(x, y, width, height, action));
+        return this;
+    }
+
+    public SimpleRichMessageBuilder addWebAction(int x, int y, int width, int height,
+                                                 @NonNull String text, @NonNull String url) {
+        return addAction(x, y, width, height, new WebRichMessageAction(text, url));
+    }
+
+    public SimpleRichMessageBuilder addSendMessageAction(int x, int y, int width, int height,
+                                                         @NonNull String message) {
+        return addAction(x, y, width, height, new SendMessageRichMessageAction(message));
+    }
+
+    public RichMessage build() {
+        final RichMessage richMessage = new RichMessage(DEFAULT_SCENE_NAME, width, height);
+        richMessage.addImage(DEFAULT_IMAGE_NAME, new RichMessageImage(0, 0, width, height));
+
+        final RichMessageScene scene = new RichMessageScene();
+        scene.addDraw(new RichMessageSceneImage(DEFAULT_IMAGE_NAME, 0, 0, width, height));
+        richMessage.addScene(DEFAULT_SCENE_NAME, scene);
+
+        int seqNo = 1;
+        for (ActionEntry entry : actions) {
+            final String name = "action" + (seqNo++);
+            richMessage.addAction(name, entry.action);
+            scene.addListener(new RichMessageSceneListener(name, entry.x, entry.y, entry.width, entry.height));
+        }
+
+        return richMessage;
+    }
+
+    private static class ActionEntry {
+
+        private final int x;
+        private final int y;
+        private final int width;
+        private final int height;
+        private final AbstractRichMessageAction action;
+
+        private ActionEntry(int x, int y, int width, int height, @NonNull AbstractRichMessageAction action) {
+            this.x = x;
+            this.y = y;
+            this.width = width;
+            this.height = height;
+            this.action = action;
+        }
+    }
+}

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/rich/SimpleRichMessageBuilderTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/rich/SimpleRichMessageBuilderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client.rich;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Collection;
+
+import org.junit.Test;
+
+import com.linecorp.bot.model.rich.RichMessage;
+import com.linecorp.bot.model.rich.RichMessageCanvas;
+import com.linecorp.bot.model.rich.RichMessageImage;
+import com.linecorp.bot.model.rich.RichMessageScene;
+import com.linecorp.bot.model.rich.RichMessageSceneImage;
+import com.linecorp.bot.model.rich.RichMessageSceneListener;
+import com.linecorp.bot.model.rich.action.AbstractRichMessageAction;
+import com.linecorp.bot.model.rich.action.SendMessageRichMessageAction;
+import com.linecorp.bot.model.rich.action.WebRichMessageAction;
+
+public class SimpleRichMessageBuilderTest {
+
+    @Test
+    public void testBuildingSimpleRichMessage() throws Exception {
+        final RichMessage richMessage =
+                SimpleRichMessageBuilder.create(1040, 520)
+                                        .addWebAction(0, 0, 520, 520, "altTxt", "https://example.com")
+                                        .addSendMessageAction(520, 0, 520, 520, "hello")
+                                        .build();
+
+        assertThat(richMessage.getCanvas(), is(new RichMessageCanvas("scene1", 1040, 520)));
+        assertThat(richMessage.getImages().values(), contains(new RichMessageImage(0, 0, 1040, 520)));
+
+        final Collection<AbstractRichMessageAction> actions = richMessage.getActions().values();
+        assertThat(actions, contains(new WebRichMessageAction("altTxt", "https://example.com"),
+                                     new SendMessageRichMessageAction("hello")));
+
+        final RichMessageScene scene = richMessage.getScenes().get("scene1");
+        assertThat(scene.getDraws(), contains(new RichMessageSceneImage("image1", 0, 0, 1040, 520)));
+        assertThat(scene.getListeners(), contains(new RichMessageSceneListener("action1", 0, 0, 520, 520),
+                                                  new RichMessageSceneListener("action2", 520, 0, 520, 520)));
+    }
+
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/rich/RichMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/rich/RichMessage.java
@@ -22,12 +22,14 @@ import java.util.Map;
 import com.linecorp.bot.model.rich.action.AbstractRichMessageAction;
 import com.linecorp.bot.model.rich.action.WebRichMessageAction;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
 
 @ToString
 @Getter
+@EqualsAndHashCode
 public class RichMessage {
     private final RichMessageCanvas canvas;
     private final Map<String, RichMessageImage> images;
@@ -35,7 +37,21 @@ public class RichMessage {
     private final Map<String, RichMessageScene> scenes;
 
     public RichMessage(int height) {
-        this.canvas = new RichMessageCanvas(height);
+        this("scene1", 1040, height);
+    }
+
+    /**
+     * Creates a new RichMessage Object with the specified size and initial scene name.
+     */
+    public RichMessage(String initialScene, int width, int height) {
+        this(new RichMessageCanvas(initialScene, width, height));
+    }
+
+    /**
+     * Creates a new RichMessage Object with the specified canvas.
+     */
+    public RichMessage(RichMessageCanvas canvas) {
+        this.canvas = canvas;
         this.images = new HashMap<>();
         this.actions = new HashMap<>();
         this.scenes = new HashMap<>();
@@ -54,7 +70,7 @@ public class RichMessage {
     }
 
     public void addImage(@NonNull String name, int h) {
-        addImage(name, new RichMessageImage(h));
+        addImage(name, new RichMessageImage(0, 0, 1040, h));
     }
 
     public void addScene(@NonNull String name, @NonNull RichMessageScene scene) {

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/rich/RichMessageCanvas.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/rich/RichMessageCanvas.java
@@ -16,52 +16,45 @@
 
 package com.linecorp.bot.model.rich;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
 @ToString
+@EqualsAndHashCode
 public class RichMessageCanvas {
+    private final String initialScene;
+    private final int width;
     private final int height;
 
     public RichMessageCanvas(int height) {
+        this("scene1", 1040, height);
+    }
+
+    /**
+     * Creates a new Canvas Object
+     *
+     * @param initialScene The initial scene
+     * @param width The base width of the canvas
+     * @param height The base height of the canvas (less than 2080px)
+     */
+    public RichMessageCanvas(@NonNull String initialScene, int width, int height) {
+        this.initialScene = initialScene;
+        this.width = width;
         this.height = vaidateHeight(height);
-    }
-
-    /**
-     * A width of the canvas area.
-     */
-    @JsonProperty("width")
-    public int getWidth() {
-        return 1040;
-    }
-
-    /**
-     * A height of the canvas area.
-     */
-    @JsonProperty("height")
-    public int getHeight() {
-        return height;
     }
 
     /**
      * Validate height.
      */
     private int vaidateHeight(int height) {
-        if (height > 2048) {
+        if (height > 2080) {
             // Integer value. Max value is 2080px.
-            throw new IllegalArgumentException("RichMessageCanvas's height should be less than or equals 2080px.");
+            throw new IllegalArgumentException(
+                    "RichMessageCanvas's height should be less than or equals 2080px.");
         }
         return height;
-    }
-
-    /**
-     * An initial scene name.
-     */
-    @JsonProperty("initialScene")
-    public String getInitialScene() {
-        return "scene1";
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/rich/RichMessageImage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/rich/RichMessageImage.java
@@ -16,32 +16,36 @@
 
 package com.linecorp.bot.model.rich;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
 @ToString
 @Getter
+@EqualsAndHashCode
 public class RichMessageImage {
+    private final int x;
+    private final int y;
+    private final int w;
     private final int h;
 
     public RichMessageImage(int h) {
+        this(0, 0, 1040, h);
+    }
+
+    /**
+     * Creates a new Image Object cropped from the base image to the specified size
+     *
+     * @param x The horizontal position of the base image
+     * @param y The vertical position of the base image
+     * @param w The width of cropping area
+     * @param h the height of cropping area
+     */
+    public RichMessageImage(int x, int y, int w, int h) {
+        this.x = x;
+        this.y = y;
+        this.w = w;
         this.h = h;
-    }
-
-    public int getX() {
-        return 0;
-    }
-
-    public int getY() {
-        return 0;
-    }
-
-    public int getW() {
-        return 1040;
-    }
-
-    public int getH() {
-        return h;
     }
 
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/rich/RichMessageScene.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/rich/RichMessageScene.java
@@ -19,32 +19,39 @@ package com.linecorp.bot.model.rich;
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
 
 @Getter
 @ToString
+@EqualsAndHashCode
 public class RichMessageScene {
     private final List<RichMessageSceneImage> draws;
     private final List<RichMessageSceneListener> listeners;
 
+    /**
+     * Creates a new Scene Object
+     */
     public RichMessageScene() {
         this.draws = new ArrayList<>();
         this.listeners = new ArrayList<>();
     }
 
-    /**
-     * Add new image.
-     *
-     * @param w width of image. one of 1040, 700, 460, 300, 240.
-     * @param h height of image(0 < h < 2080)
-     */
+    public void addDraw(@NonNull RichMessageSceneImage draw) {
+        this.draws.add(draw);
+    }
+
     public void addDraw(int w, int h) {
-        this.draws.add(new RichMessageSceneImage(w, h));
+        addDraw(new RichMessageSceneImage("image1", 0, 0, w, h));
+    }
+
+    public void addListener(@NonNull RichMessageSceneListener listener) {
+        this.listeners.add(listener);
     }
 
     public void addListener(int x, int y, int width, int height, @NonNull String action) {
-        this.listeners.add(new RichMessageSceneListener(action, x, y, width, height));
+        addListener(new RichMessageSceneListener(action, x, y, width, height));
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/rich/RichMessageSceneImage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/rich/RichMessageSceneImage.java
@@ -16,77 +16,53 @@
 
 package com.linecorp.bot.model.rich;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.ToString;
 
 @ToString
 @Getter
+@EqualsAndHashCode
 public class RichMessageSceneImage {
+
+    private final String image;
+    private final int x;
+    private final int y;
     private final int w;
     private final int h;
 
-    /**
-     * Create new image.
-     *
-     * @param w width of image. one of 1040, 700, 460, 300, 240.
-     * @param h height of image(0 < h < 2080)
-     */
     public RichMessageSceneImage(int w, int h) {
-        this.w = validateWidth(w);
-        this.h = validateHeight(h);
+        this("image1", 0, 0, w, h);
     }
 
     /**
-     * The image ID.
-     */
-    public String getImage() {
-        return "image1";
-    }
-
-    /**
-     * x-coordinate value.
-     */
-    public int getX() {
-        return 0;
-    }
-
-    /**
-     * y-coordinate value.
-     */
-    public int getY() {
-        return 0;
-    }
-
-    public int getW() {
-        return w;
-    }
-
-    /**
-     * Validate width.
+     * Creates a new Draw Object indicating the position to draw the image.
      *
-     * @param w one of 1040, 700, 460, 300, 240.
+     * @param image The name of image object
+     * @param x The horizontal position in the canvas
+     * @param y The vertical position in the canvas
+     * @param w The width to draw the image in the canvas
+     * @param h The height to draw the image in the canvas
      */
-    private int validateWidth(int w) {
-        // 1040, 700, 460, 300, 240
-        if ((w != 1040) && (w != 700) && (w != 460) && (w != 300) && (w != 240)) {
-            throw new IllegalArgumentException("Scene width must be one of 1040, 700, 460, 300 or 240.");
-        }
-        return w;
-    }
-
-    public int getH() {
-        return h;
+    public RichMessageSceneImage(@NonNull String image, int x, int y, int w, int h) {
+        this.image = image;
+        this.x = x;
+        this.y = y;
+        this.w = w;
+        this.h = validateHeight(h);
     }
 
     /**
      * Validate height.
      *
-     * @param h the height of image (0 < h < 2080).
+     * @param h the height of image (0 < h <= 2080).
      */
     private int validateHeight(int h) {
         if (h > 2080) {
             // Integer value. Max value is 2080px.
-            throw new IllegalArgumentException("RichMessageImage's height should be less than or equals 2080px.");
+            throw new IllegalArgumentException(
+                    "RichMessageImage's height should be less than or equals 2080px.");
         }
         if (h < 1) {
             // Integer value. Max value is 2080px.

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/rich/RichMessageSceneListener.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/rich/RichMessageSceneListener.java
@@ -19,7 +19,9 @@ package com.linecorp.bot.model.rich;
 import java.util.Arrays;
 import java.util.List;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.ToString;
 
 /**
@@ -28,6 +30,7 @@ import lombok.ToString;
  */
 @Getter
 @ToString
+@EqualsAndHashCode
 public class RichMessageSceneListener {
 
     /**
@@ -39,7 +42,16 @@ public class RichMessageSceneListener {
      */
     private final String action;
 
-    public RichMessageSceneListener(String action, int x, int y, int width, int height) {
+    /**
+     * Creates a new Listener Object indicating the position to execute the specified action
+     *
+     * @param action The action name to be executed
+     * @param x The vertical position of the target area
+     * @param y The horizontal position of the target area
+     * @param width The width of the target area
+     * @param height The height of the target area
+     */
+    public RichMessageSceneListener(@NonNull String action, int x, int y, int width, int height) {
         this.params = Arrays.asList(x, y, width, height);
         this.action = action;
     }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/rich/action/AbstractRichMessageAction.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/rich/action/AbstractRichMessageAction.java
@@ -16,10 +16,12 @@
 
 package com.linecorp.bot.model.rich.action;
 
+import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
 
 @ToString
+@EqualsAndHashCode
 public abstract class AbstractRichMessageAction {
     private final String type;
 

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/rich/action/SendMessageRichMessageAction.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/rich/action/SendMessageRichMessageAction.java
@@ -16,11 +16,13 @@
 
 package com.linecorp.bot.model.rich.action;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
 
 @ToString
+@EqualsAndHashCode(callSuper = true)
 public class SendMessageRichMessageAction extends AbstractRichMessageAction {
     private final SendMessageRichMessageActionParams params;
 
@@ -33,6 +35,7 @@ public class SendMessageRichMessageAction extends AbstractRichMessageAction {
 
     @Getter
     @ToString
+    @EqualsAndHashCode
     public static class SendMessageRichMessageActionParams {
         private final String text;
 

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/rich/action/WebRichMessageAction.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/rich/action/WebRichMessageAction.java
@@ -16,11 +16,13 @@
 
 package com.linecorp.bot.model.rich.action;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
 
 @ToString
+@EqualsAndHashCode(callSuper = true)
 public class WebRichMessageAction extends AbstractRichMessageAction {
     private final String text;
     private final WebRichMessageActionParams params;
@@ -37,6 +39,7 @@ public class WebRichMessageAction extends AbstractRichMessageAction {
 
     @Getter
     @ToString
+    @EqualsAndHashCode
     public static class WebRichMessageActionParams {
         private final String linkUri;
 

--- a/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/KitchenSinkController.java
+++ b/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/KitchenSinkController.java
@@ -34,6 +34,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import com.linecorp.bot.client.CloseableMessageContent;
 import com.linecorp.bot.client.LineBotClient;
 import com.linecorp.bot.client.exception.LineBotAPIException;
+import com.linecorp.bot.client.rich.SimpleRichMessageBuilder;
 import com.linecorp.bot.model.callback.Message;
 import com.linecorp.bot.model.content.AddedAsFriendOperation;
 import com.linecorp.bot.model.content.AudioContent;
@@ -51,7 +52,6 @@ import com.linecorp.bot.model.content.metadata.ContactContentMetadata;
 import com.linecorp.bot.model.content.metadata.StickerContentMetadata;
 import com.linecorp.bot.model.profile.UserProfileResponse;
 import com.linecorp.bot.model.rich.RichMessage;
-import com.linecorp.bot.model.rich.RichMessageScene;
 import com.linecorp.bot.spring.boot.annotation.LineBotMessages;
 
 import lombok.NonNull;
@@ -245,21 +245,13 @@ public class KitchenSinkController {
                              .send(mid);
                 break;
             case "rich":
-                RichMessage richMessage = new RichMessage(1040);
-                richMessage.addWebAction("MANGA", "play", "https://store.line.me/family/manga/en");
-                richMessage.addWebAction("MUSIC", "music", "https://store.line.me/family/music/en");
-                richMessage.addWebAction("PLAY", "play", "https://store.line.me/family/play/en");
-                richMessage.addWebAction("FORTUNE", "play", "https://store.line.me/family/uranai/en");
-                richMessage.addImage("image1", 1040);
-
-                RichMessageScene scene = new RichMessageScene();
-                scene.addDraw(1040, 1040);
-                scene.addListener(0, 0, 1040 / 2, 1040 / 2, "MANGA");
-                scene.addListener(1040 / 2, 0, 1040 / 2, 1040 / 2, "MUSIC");
-                scene.addListener(0, 1040 / 2, 1040 / 2, 1040 / 2, "PLAY");
-                scene.addListener(1040 / 2, 1040 / 2, 1040 / 2, 1040 / 2, "FORTUNE");
-
-                richMessage.addScene("scene1", scene);
+                final RichMessage richMessage =
+                        SimpleRichMessageBuilder.create(1040, 1040)
+                        .addWebAction(0, 0, 520, 520, "manga", "https://store.line.me/family/manga/en")
+                        .addWebAction(520, 0, 520, 520, "music", "https://store.line.me/family/music/en")
+                        .addWebAction(0, 520, 520, 520, "play", "https://store.line.me/family/play/en")
+                        .addWebAction(520, 520, 520, 520, "fortune", "https://store.line.me/family/uranai/en")
+                        .build();
 
                 lineBotClient.sendRichMessage(
                         mid,


### PR DESCRIPTION
Unfortunately, Our api doc for richmessage is very confusing in the point of view of "spec" and "typical usage". 
https://developers.line.me/bot-api/api-reference#sending_rich_content_message

In my understand, The following descriptions in api doc are not the spec but just typical usages:
* Fixed string “scene1″
* You should use the ID image1 as the image’s property name.
* The draw width is "Any one of 1040, 700, 460, 300, 240."
* etc

In this PR, I'd like to separate the spec and typical usages.
* Refactoring the models to represent the spec precisely
* Add `SimpleRichMessageBuilder` to create a typical RichMessage easily.

The builder simplifies the creation of a typical rich message.
```
RichMessage richMessage =
                SimpleRichMessageBuilder.create(1040, 520)
                                        .addWebAction(0, 0, 520, 520, "altTxt", "https://example.com")
                                        .addSendMessageAction(520, 0, 520, 520, "hello")
                                        .build();
```

Of course, developers can also build more complex (but legal) rich messages by dealing with the models directly.