### PR TITLE
JoinEvent#source and LeaveEvent#source should use generic Source type.

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/JoinEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/JoinEvent.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import com.linecorp.bot.model.event.source.GroupSource;
+import com.linecorp.bot.model.event.source.Source;
 
 import lombok.Value;
 
@@ -30,7 +31,7 @@ import lombok.Value;
 @JsonTypeName("join")
 public class JoinEvent implements Event {
     private final String replyToken;
-    private final GroupSource source;
+    private final Source source;
     private final Instant timestamp;
 
     @JsonCreator

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/JoinEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/JoinEvent.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import com.linecorp.bot.model.event.source.GroupSource;
 import com.linecorp.bot.model.event.source.Source;
 
 import lombok.Value;
@@ -37,7 +36,7 @@ public class JoinEvent implements Event {
     @JsonCreator
     public JoinEvent(
             @JsonProperty("replyToken") String replyToken,
-            @JsonProperty("source") GroupSource source,
+            @JsonProperty("source") Source source,
             @JsonProperty("timestamp") Instant timestamp) {
         this.replyToken = replyToken;
         this.source = source;

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/LeaveEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/LeaveEvent.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import com.linecorp.bot.model.event.source.GroupSource;
 import com.linecorp.bot.model.event.source.Source;
 
 import lombok.Value;
@@ -35,7 +34,7 @@ public class LeaveEvent implements Event {
 
     @JsonCreator
     public LeaveEvent(
-            @JsonProperty("source") GroupSource source,
+            @JsonProperty("source") Source source,
             @JsonProperty("timestamp") Instant timestamp) {
         this.source = source;
         this.timestamp = timestamp;

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/LeaveEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/LeaveEvent.java
@@ -23,13 +23,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import com.linecorp.bot.model.event.source.GroupSource;
+import com.linecorp.bot.model.event.source.Source;
 
 import lombok.Value;
 
 @Value
 @JsonTypeName("leave")
 public class LeaveEvent implements Event {
-    private final GroupSource source;
+    private final Source source;
     private final Instant timestamp;
 
     @JsonCreator


### PR DESCRIPTION
Because join/leave events caused by talk room.