### PR TITLE
add webhook parser module with deserialize exception options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,17 @@ subprojects {
         }
     }
 
+    findbugs {
+        excludeFilter = file("${project.rootDir}/settings/findbugs/exclude_filter.xml")
+    }
+
+    tasks.withType(FindBugs) {
+        reports {
+            xml.enabled = false
+            html.enabled = true
+        }
+    }
+
     project.plugins.withType(org.springframework.boot.gradle.plugin.SpringBootPlugin) {
         bootRun {
             systemProperties System.properties

--- a/line-bot-servlet/src/main/java/com/linecorp/bot/servlet/LineBotCallbackRequestParser.java
+++ b/line-bot-servlet/src/main/java/com/linecorp/bot/servlet/LineBotCallbackRequestParser.java
@@ -65,7 +65,9 @@ public class LineBotCallbackRequestParser {
      * Parse request.
      *
      * @param req HTTP servlet request.
+     *
      * @return Parsed result. If there's an error, this method sends response.
+     *
      * @throws LineBotCallbackException There's an error around signature.
      */
     public CallbackRequest handle(HttpServletRequest req) throws LineBotCallbackException, IOException {

--- a/line-bot-webhook-parser/build.gradle
+++ b/line-bot-webhook-parser/build.gradle
@@ -15,9 +15,8 @@
  */
 
 dependencies {
-    compile project(':line-bot-webhook-parser')
-    compile 'com.google.guava:guava'
+    compile project(':line-bot-api-client')
+    compile 'com.fasterxml.jackson.core:jackson-databind'
 
-    optional 'javax.servlet:javax.servlet-api'
     optional 'org.slf4j:slf4j-api'
 }

--- a/line-bot-webhook-parser/src/main/java/com/linecorp/bot/parser/LineBotCallbackRequestDeserializer.java
+++ b/line-bot-webhook-parser/src/main/java/com/linecorp/bot/parser/LineBotCallbackRequestDeserializer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.parser;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import com.linecorp.bot.model.event.CallbackRequest;
+import com.linecorp.bot.model.event.Event;
+
+class LineBotCallbackRequestDeserializer extends JsonDeserializer<CallbackRequest> {
+    private final LineBotDeserializerOption deserializeOption;
+
+    LineBotCallbackRequestDeserializer(LineBotDeserializerOption deserializeOption) {
+        this.deserializeOption = deserializeOption;
+    }
+
+    @Override
+    public CallbackRequest deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        final JsonNode node = p.getCodec().readTree(p);
+        if (!node.isObject()) {
+            throw new LineBotWebhookParseException("request body is not json object");
+        }
+
+        final JsonNode eventsNode = node.get("events");
+        if (eventsNode == null || !eventsNode.isArray()) {
+            throw new LineBotWebhookParseException("`events` is not array");
+        }
+
+        final ArrayNode arrayNode = (ArrayNode) eventsNode;
+        final List<Event> result = new ArrayList<>();
+        final ObjectCodec codec = p.getCodec();
+        for (JsonNode n : arrayNode) {
+            try {
+                result.add(codec.treeToValue(n, Event.class));
+            } catch (JsonProcessingException e) {
+                final Event fallback = deserializeOption.getDeserializeExceptionHandler().apply(e);
+                if (fallback != null || !deserializeOption.isSkipNull()) {
+                    result.add(fallback);
+                }
+            }
+        }
+        return new CallbackRequest(result);
+    }
+}

--- a/line-bot-webhook-parser/src/main/java/com/linecorp/bot/parser/LineBotDeserializerOption.java
+++ b/line-bot-webhook-parser/src/main/java/com/linecorp/bot/parser/LineBotDeserializerOption.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.parser;
+
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+
+import com.linecorp.bot.model.event.Event;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+public class LineBotDeserializerOption {
+    private final DeserializeExceptionHandler deserializeExceptionHandler;
+    private final boolean skipNull;
+
+    /**
+     * event deserialize exception handler
+     *
+     * @param deserializeExceptionHandler deserialize exception handler
+     * @param skipNull if exception handler return null, skip the event
+     */
+    public LineBotDeserializerOption(
+            DeserializeExceptionHandler deserializeExceptionHandler,
+            boolean skipNull
+    ) {
+        this.deserializeExceptionHandler = deserializeExceptionHandler;
+        this.skipNull = skipNull;
+    }
+
+    /**
+     * warn logging and skip unknown event option
+     */
+    public static LineBotDeserializerOption getDefault() {
+        return new LineBotDeserializerOption(
+                getWarnLoggingAndReturnNullHandler(),
+                true
+        );
+    }
+
+    /**
+     * throw exception handler
+     */
+    public static DeserializeExceptionHandler getThrowExceptionHandler() {
+        return th -> {
+            if (th instanceof InvalidTypeIdException) {
+                throw new LineBotWebhookParseException(
+                        "Unknown `type` Found, Please Upgrade module: " + th.getMessage(), th);
+            } else {
+                throw new LineBotWebhookParseException(
+                        "Failed to deserialize events. Please Upgrade module. " + th.getMessage(), th);
+            }
+        };
+    }
+
+    /**
+     * warn logging and return null handler
+     */
+    public static DeserializeExceptionHandler getWarnLoggingAndReturnNullHandler() {
+        return th -> {
+            if (th instanceof InvalidTypeIdException) {
+                log.warn("Unknown `type` Found, Please Upgrade module (this event is skipped): {}",
+                         th.getMessage());
+            } else {
+                log.warn("Failed to deserialize, this event is skipped. Please Upgrade module: {}",
+                         th.getMessage());
+            }
+            return null;
+        };
+    }
+
+    @FunctionalInterface
+    public interface DeserializeExceptionHandler {
+        Event apply(Throwable th) throws LineBotWebhookParseException;
+    }
+}

--- a/line-bot-webhook-parser/src/main/java/com/linecorp/bot/parser/LineBotWebhookParseException.java
+++ b/line-bot-webhook-parser/src/main/java/com/linecorp/bot/parser/LineBotWebhookParseException.java
@@ -14,10 +14,18 @@
  * under the License.
  */
 
-dependencies {
-    compile project(':line-bot-webhook-parser')
-    compile 'com.google.guava:guava'
+package com.linecorp.bot.parser;
 
-    optional 'javax.servlet:javax.servlet-api'
-    optional 'org.slf4j:slf4j-api'
+import java.io.IOException;
+
+public class LineBotWebhookParseException extends IOException {
+    private static final long serialVersionUID = -2288821098916603128L;
+
+    LineBotWebhookParseException(String message) {
+        super(message);
+    }
+
+    LineBotWebhookParseException(String message, Throwable th) {
+        super(message, th);
+    }
 }

--- a/line-bot-webhook-parser/src/main/java/com/linecorp/bot/parser/LineBotWebhookParser.java
+++ b/line-bot-webhook-parser/src/main/java/com/linecorp/bot/parser/LineBotWebhookParser.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.parser;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import com.linecorp.bot.model.event.CallbackRequest;
+
+public class LineBotWebhookParser {
+    private final ObjectReader objectReader;
+
+    public LineBotWebhookParser() {
+        this(LineBotDeserializerOption.getDefault());
+    }
+
+    public LineBotWebhookParser(LineBotDeserializerOption deserializerOption) {
+        this.objectReader = buildObjectReader(deserializerOption);
+    }
+
+    public CallbackRequest parse(byte[] body) throws LineBotWebhookParseException {
+        try {
+            return objectReader.readValue(body);
+        } catch (IOException e) {
+            throw new LineBotWebhookParseException("failed to parse webhook body", e);
+        }
+    }
+
+    private static ObjectReader buildObjectReader(
+            LineBotDeserializerOption deserializerOption
+    ) {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        // Register JSR-310(java.time.temporal.*) module and read number as millsec.
+        objectMapper.registerModule(new JavaTimeModule())
+                    .configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
+
+        final LineBotCallbackRequestDeserializer deserializer =
+                new LineBotCallbackRequestDeserializer(deserializerOption);
+        final LineBotWebhookParserModule
+                lineBotWebhookParserModule = new LineBotWebhookParserModule(deserializer);
+        objectMapper.registerModule(lineBotWebhookParserModule);
+
+        return objectMapper.readerFor(CallbackRequest.class);
+    }
+}

--- a/line-bot-webhook-parser/src/main/java/com/linecorp/bot/parser/LineBotWebhookParserModule.java
+++ b/line-bot-webhook-parser/src/main/java/com/linecorp/bot/parser/LineBotWebhookParserModule.java
@@ -14,10 +14,19 @@
  * under the License.
  */
 
-dependencies {
-    compile project(':line-bot-webhook-parser')
-    compile 'com.google.guava:guava'
+package com.linecorp.bot.parser;
 
-    optional 'javax.servlet:javax.servlet-api'
-    optional 'org.slf4j:slf4j-api'
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import com.linecorp.bot.model.event.CallbackRequest;
+
+class LineBotWebhookParserModule extends SimpleModule {
+    private static final long serialVersionUID = 1592842153305097463L;
+
+    LineBotWebhookParserModule(LineBotCallbackRequestDeserializer lineBotCallbackRequestDeserializer) {
+        super(new Version(0, 1, 0, null, null, null));
+
+        this.addDeserializer(CallbackRequest.class, lineBotCallbackRequestDeserializer);
+    }
 }

--- a/line-bot-webhook-parser/src/test/java/com/linecorp/bot/parser/LineBotWebhookParserTest.java
+++ b/line-bot-webhook-parser/src/test/java/com/linecorp/bot/parser/LineBotWebhookParserTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.Test;
+import org.springframework.util.StreamUtils;
+
+import com.linecorp.bot.model.event.CallbackRequest;
+
+public class LineBotWebhookParserTest {
+
+    @Test
+    public void testParseWithDefaultDeserializeOption() throws Exception {
+        final byte[] json = readResource("callback/unknown-message.json");
+        final LineBotWebhookParser parser = new LineBotWebhookParser();
+        // skip unknown message event with warn logging
+        final CallbackRequest req = parser.parse(json);
+        assertThat(req).isNotNull();
+        assertThat(req.getEvents()).hasSize(2);
+        assertThat(req.getEvents().get(0).getSource().getSenderId())
+                .isEqualTo("u00000000000000000000000000000000");
+        assertThat(req.getEvents().get(1).getSource().getSenderId())
+                .isEqualTo("u00000000000000000000000000000002");
+    }
+
+    @Test
+    public void testParseWithNonSkipNullOption() throws Exception {
+        final byte[] json = readResource("callback/unknown-message.json");
+        final LineBotWebhookParser parser = new LineBotWebhookParser(
+                new LineBotDeserializerOption(
+                        LineBotDeserializerOption.getWarnLoggingAndReturnNullHandler(),
+                        false
+                )
+        );
+        final CallbackRequest req = parser.parse(json);
+        assertThat(req).isNotNull();
+        assertThat(req.getEvents()).hasSize(3);
+        assertThat(req.getEvents().get(0).getSource().getSenderId())
+                .isEqualTo("u00000000000000000000000000000000");
+        assertThat(req.getEvents().get(1)).isNull();
+        assertThat(req.getEvents().get(2).getSource().getSenderId())
+                .isEqualTo("u00000000000000000000000000000002");
+    }
+
+    @Test(expected = LineBotWebhookParseException.class)
+    public void testParseWithThrowExceptionOption() throws Exception {
+        final byte[] json = readResource("callback/unknown-message.json");
+        final LineBotWebhookParser parser = new LineBotWebhookParser(
+                new LineBotDeserializerOption(
+                        LineBotDeserializerOption.getThrowExceptionHandler(),
+                        false
+                )
+        );
+        parser.parse(json);
+    }
+
+    private byte[] readResource(String resourceName) throws IOException {
+        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(resourceName)) {
+            return StreamUtils.copyToByteArray(inputStream);
+        }
+    }
+}

--- a/line-bot-webhook-parser/src/test/resources/callback/unknown-message.json
+++ b/line-bot-webhook-parser/src/test/resources/callback/unknown-message.json
@@ -1,0 +1,46 @@
+{
+  "events": [
+    {
+      "replyToken": "nHuyWiB7yP5Zw52FIkcQobQuGDXCTA",
+      "type": "message",
+      "timestamp": 1462629479859,
+      "source": {
+        "type": "user",
+        "userId": "u00000000000000000000000000000000"
+      },
+      "message": {
+        "id": "325708",
+        "type": "text",
+        "text": "Hello, world"
+      }
+    },
+    {
+      "replyToken": "nHuyWiB7yP5Zw52FIkcQobQuGDXCTA",
+      "type": "message",
+      "timestamp": 1462629479859,
+      "source": {
+        "type": "user",
+        "userId": "u00000000000000000000000000000001"
+      },
+      "message": {
+        "id": "325708",
+        "type": "unknown",
+        "unknown": "blah blah"
+      }
+    },
+    {
+      "replyToken": "nHuyWiB7yP5Zw52FIkcQobQuGDXCTA",
+      "type": "message",
+      "timestamp": 1462629479859,
+      "source": {
+        "type": "user",
+        "userId": "u00000000000000000000000000000002"
+      },
+      "message": {
+        "id": "325708",
+        "type": "text",
+        "text": "Hello, world"
+      }
+    }
+  ]
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 include 'line-bot-api-client'
 include 'line-bot-model'
+include 'line-bot-webhook-parser'
 include 'line-bot-servlet'
 include 'line-bot-spring-boot'
 

--- a/settings/findbugs/exclude_filter.xml
+++ b/settings/findbugs/exclude_filter.xml
@@ -1,0 +1,6 @@
+<FindBugsFilter>
+  <Match>
+    <Class name="com.linecorp.bot.servlet.LineBotCallbackRequestParser"/>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
## Problems
parser throw `InvalidTypeIdException` exception when receiving `message.type="unknown"`.
and throw away other valid events if webhook include corrent and incorrect events.
(btw, only `event.type` has defaultImpl `UnknownEvent`)

## Suggestion
add webhook parser module which handle deserialize exception for each event.
such as if find unknown type, skip only it (default impl), throw exception, etc..

## Future Plan
remove event.type defaultImpl.