### PR TITLE
NO-ISSUE Fix log message.

### DIFF
--- a/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/KitchenSinkController.java
+++ b/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/KitchenSinkController.java
@@ -397,7 +397,7 @@ public class KitchenSinkController {
     }
 
     private static DownloadedContent saveContent(String ext, ResponseBody responseBody) {
-        log.info("Got filename: {}", responseBody.contentType());
+        log.info("Got content-type: {}", responseBody.contentType());
         DownloadedContent tempFile = createTempFile(ext);
         try (OutputStream outputStream = Files.newOutputStream(tempFile.path)) {
             ByteStreams.copy(responseBody.byteStream(), outputStream);


### PR DESCRIPTION
Memo
-----
Current response header. (Of course, it is not a SPEC)

```
com.linecorp.bot.client.wire             : --> GET https://api.line.me/v2/bot/message/1/content http/1.1
com.linecorp.bot.client.wire             : Authorization: Bearer xxx
com.linecorp.bot.client.wire             : User-Agent: line-botsdk-java/null
com.linecorp.bot.client.wire             : --> END GET
com.linecorp.bot.client.wire             : <-- 200  https://api.line.me/v2/bot/message/1/content (295ms)
com.linecorp.bot.client.wire             : Server: nginx
com.linecorp.bot.client.wire             : Date: Sat, 22 Oct 2016 04:25:54 GMT
com.linecorp.bot.client.wire             : Content-Type: image/jpeg
com.linecorp.bot.client.wire             : Content-Length: 10513
com.linecorp.bot.client.wire             : Connection: keep-alive
com.linecorp.bot.client.wire             : X-Line-Request-Id: 9efd0097-70a0-4df5-a876-5c46946a5ae7
com.linecorp.bot.client.wire             : Content-Disposition: attachment; filename="1477110350760.jpg"
com.linecorp.bot.client.wire             : X-Content-Type-Options: nosniff
com.linecorp.bot.client.wire             : X-XSS-Protection: 1; mode=block
com.linecorp.bot.client.wire             : Cache-Control: no-cache, no-store, max-age=0, must-revalidate
com.linecorp.bot.client.wire             : Pragma: no-cache
com.linecorp.bot.client.wire             : Expires: 0
com.linecorp.bot.client.wire             : X-Frame-Options: DENY
com.linecorp.bot.client.wire             : 
com.linecorp.bot.client.wire             : <-- END HTTP (binary 10513-byte body omitted)
```