### PR TITLE
improve callback parser object mapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ subprojects {
             dependency 'com.squareup.okhttp3:mockwebserver:' + ext['okhttp3.version'] // Additional okhttp3 modules. Using Spring IO version variable.
             dependency 'com.squareup.retrofit2:converter-jackson:2.1.0'
             dependency 'com.squareup.retrofit2:retrofit:2.1.0'
+            dependency 'com.fasterxml.jackson.module:jackson-module-afterburner:2.8.4'
             dependency 'org.assertj:assertj-core:3.5.2' // Update from 2.5.0 (by Spring-Boot and Spring IO)
         }
     }

--- a/line-bot-model/build.gradle
+++ b/line-bot-model/build.gradle
@@ -20,4 +20,5 @@ dependencies {
     compile 'com.fasterxml.jackson.core:jackson-annotations'
 
     testCompile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    testCompile 'com.fasterxml.jackson.module:jackson-module-afterburner'
 }

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
@@ -29,6 +29,7 @@ import org.springframework.util.StreamUtils;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 
 import com.linecorp.bot.model.event.message.ImageMessageContent;
 import com.linecorp.bot.model.event.message.LocationMessageContent;
@@ -50,6 +51,7 @@ public class CallbackRequestTest {
             objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             objectMapper.registerModule(new JavaTimeModule())
                         .configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
+            objectMapper.registerModule(new AfterburnerModule());
             CallbackRequest callbackRequest = objectMapper.readValue(json, CallbackRequest.class);
 
             callback.call(callbackRequest);

--- a/line-bot-servlet/build.gradle
+++ b/line-bot-servlet/build.gradle
@@ -17,6 +17,7 @@
 dependencies {
     compile project(':line-bot-api-client')
     compile 'com.fasterxml.jackson.core:jackson-databind'
+    compile 'com.fasterxml.jackson.module:jackson-module-afterburner'
     compile 'com.google.guava:guava'
 
     optional 'javax.servlet:javax.servlet-api'

--- a/line-bot-servlet/src/main/java/com/linecorp/bot/servlet/LineBotCallbackRequestParser.java
+++ b/line-bot-servlet/src/main/java/com/linecorp/bot/servlet/LineBotCallbackRequestParser.java
@@ -23,7 +23,9 @@ import javax.servlet.http.HttpServletRequest;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import com.google.common.io.ByteStreams;
 
 import com.linecorp.bot.client.LineSignatureValidator;
@@ -35,7 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class LineBotCallbackRequestParser {
     private final LineSignatureValidator lineSignatureValidator;
-    private final ObjectMapper objectMapper;
+    private final ObjectReader callbackRequestObjectReader;
 
     /**
      * Create new instance
@@ -45,7 +47,7 @@ public class LineBotCallbackRequestParser {
     public LineBotCallbackRequestParser(
             @NonNull LineSignatureValidator lineSignatureValidator) {
         this.lineSignatureValidator = lineSignatureValidator;
-        this.objectMapper = buildObjectMapper();
+        this.callbackRequestObjectReader = buildCallbackRequestObjectReader();
     }
 
     /**
@@ -71,20 +73,21 @@ public class LineBotCallbackRequestParser {
             throw new LineBotCallbackException("Invalid API signature");
         }
 
-        final CallbackRequest callbackRequest = objectMapper.readValue(json, CallbackRequest.class);
+        final CallbackRequest callbackRequest = callbackRequestObjectReader.readValue(json);
         if (callbackRequest == null || callbackRequest.getEvents() == null) {
             throw new LineBotCallbackException("Invalid content");
         }
         return callbackRequest;
     }
 
-    private static ObjectMapper buildObjectMapper() {
+    private static ObjectReader buildCallbackRequestObjectReader() {
         final ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
         // Register JSR-310(java.time.temporal.*) module and read number as millsec.
         objectMapper.registerModule(new JavaTimeModule())
                     .configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
-        return objectMapper;
+        objectMapper.registerModule(new AfterburnerModule());
+        return objectMapper.readerFor(CallbackRequest.class);
     }
 }


### PR DESCRIPTION
- add [AfterBurnerModule](https://github.com/FasterXML/jackson-module-afterburner)
- use ObjectReader directly

ref [Jackson でハイパフォーマンスな JSON 処理を追求する (第十七回 #渋谷java でお話してきました)](http://k11i.biz/blog/2016/10/01/high-performance-jackson/)