### PR TITLE
Use Java8's CompletableFuture instead of Retorofit's Call.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ subprojects {
         testCompile 'com.squareup.okhttp3:mockwebserver'
         testCompile 'org.hibernate:hibernate-validator'
         testCompile 'org.springframework.boot:spring-boot-starter-test' // MockHttpServletRequest
-        testRuntime 'org.springframework.boot:spring-boot-starter-logging'
+        testCompile 'org.springframework.boot:spring-boot-starter-logging'
     }
 
     compileJava.dependsOn(processResources) // http://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html#configuration-metadata-annotation-processor

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/ExceptionConverter.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/ExceptionConverter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+import com.linecorp.bot.client.exception.BadRequestException;
+import com.linecorp.bot.client.exception.ForbiddenException;
+import com.linecorp.bot.client.exception.GeneralLineMessagingException;
+import com.linecorp.bot.client.exception.LineMessagingException;
+import com.linecorp.bot.client.exception.LineServerException;
+import com.linecorp.bot.client.exception.TooManyRequestsException;
+import com.linecorp.bot.client.exception.UnauthorizedException;
+import com.linecorp.bot.model.error.ErrorResponse;
+
+import okhttp3.ResponseBody;
+import retrofit2.Response;
+
+class ExceptionConverter implements Function<Response<?>, LineMessagingException> {
+    public static final ObjectReader OBJECT_READER = new ObjectMapper().readerFor(ErrorResponse.class);
+
+    @Override
+    public LineMessagingException apply(Response<?> response) {
+        try {
+            return applyInternal(response.code(), response.errorBody());
+        } catch (Exception e) {
+            return new GeneralLineMessagingException(e.getMessage(), null, e);
+        }
+    }
+
+    private static LineMessagingException applyInternal(final int code, final ResponseBody responseBody)
+            throws IOException {
+        final ErrorResponse errorResponse = OBJECT_READER.readValue(responseBody.byteStream());
+
+        switch (code) {
+            case 400:
+                return new BadRequestException(
+                        errorResponse.getMessage(), errorResponse);
+            case 401:
+                return new UnauthorizedException(
+                        errorResponse.getMessage(), errorResponse);
+            case 403:
+                return new ForbiddenException(
+                        errorResponse.getMessage(), errorResponse);
+            case 429:
+                return new TooManyRequestsException(
+                        errorResponse.getMessage(), errorResponse);
+            case 500:
+                return new LineServerException(
+                        errorResponse.getMessage(), errorResponse);
+        }
+
+        return new GeneralLineMessagingException(errorResponse.getMessage(), errorResponse, null);
+    }
+}

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClient.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClient.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.linecorp.bot.model.PushMessage;
+import com.linecorp.bot.model.ReplyMessage;
+import com.linecorp.bot.model.profile.UserProfileResponse;
+import com.linecorp.bot.model.response.BotApiResponse;
+
+public interface LineMessagingClient {
+    /**
+     * Reply to messages from users.
+     *
+     * <p>Webhooks are used to notify you when an event occurs. For events that you can respond to,
+     * a replyToken is issued for replying to messages.
+     * <p>Because the replyToken becomes invalid after a certain period of time,
+     * responses should be sent as soon as a message is received. Reply tokens can only be used once.
+     *
+     * @see #pushMessage(PushMessage)
+     * @see <a href="https://devdocs.line.me?java#reply-message">//devdocs.line.me#reply-message</a>
+     */
+    CompletableFuture<BotApiResponse> replyMessage(ReplyMessage replyMessage);
+
+    /**
+     * Send messages to users when you want to.
+     *
+     * <p>INFO: Use of the Push Message API is limited to certain plans.
+     *
+     * @see #replyMessage(ReplyMessage)
+     * @see <a href="https://devdocs.line.me?java#push-message">//devdocs.line.me#push-message</a>
+     */
+    CompletableFuture<BotApiResponse> pushMessage(PushMessage pushMessage);
+
+    /**
+     * Download image, video, and audio data sent from users.
+     *
+     * @see <a href="https://devdocs.line.me?java#get-content">//devdocs.line.me#get-content</a>
+     */
+    CompletableFuture<MessageContentResponse> getMessageContent(String messageId);
+
+    /**
+     * Get user profile information.
+     *
+     * @see <a href="https://devdocs.line.me?java#bot-api-get-profile">//devdocs.line.me#bot-api-get-profile</a>
+     */
+    CompletableFuture<UserProfileResponse> getProfile(String userId);
+
+    /**
+     * Leave a group.
+     *
+     * @see <a href="https://devdocs.line.me?java#leave">//devdocs.line.me#leave</a>
+     */
+    CompletableFuture<BotApiResponse> leaveGroup(String groupId);
+
+    /**
+     * Leave a room.
+     *
+     * @see <a href="https://devdocs.line.me?java#leave">//devdocs.line.me#leave</a>
+     */
+    CompletableFuture<BotApiResponse> leaveRoom(String roomId);
+}

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClientImpl.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClientImpl.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.linecorp.bot.client.exception.GeneralLineMessagingException;
+import com.linecorp.bot.model.PushMessage;
+import com.linecorp.bot.model.ReplyMessage;
+import com.linecorp.bot.model.profile.UserProfileResponse;
+import com.linecorp.bot.model.response.BotApiResponse;
+
+import lombok.AllArgsConstructor;
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+/**
+ * Proxy implementation of {@link LineMessagingClient} to hind internal implementation.
+ */
+@AllArgsConstructor
+public class LineMessagingClientImpl implements LineMessagingClient {
+    private static final ExceptionConverter EXCEPTION_CONVERTER = new ExceptionConverter();
+    private final LineMessagingService retrofitImpl;
+
+    @Override
+    public CompletableFuture<BotApiResponse> replyMessage(final ReplyMessage replyMessage) {
+        return toFuture(retrofitImpl.replyMessage(replyMessage));
+    }
+
+    @Override
+    public CompletableFuture<BotApiResponse> pushMessage(final PushMessage pushMessage) {
+        return toFuture(retrofitImpl.pushMessage(pushMessage));
+    }
+
+    @Override
+    public CompletableFuture<MessageContentResponse> getMessageContent(final String messageId) {
+        return toMessageContentResponseFuture(retrofitImpl.getMessageContent(messageId));
+    }
+
+    @Override
+    public CompletableFuture<UserProfileResponse> getProfile(final String userId) {
+        return toFuture(retrofitImpl.getProfile(userId));
+    }
+
+    @Override
+    public CompletableFuture<BotApiResponse> leaveGroup(final String groupId) {
+        return toFuture(retrofitImpl.leaveGroup(groupId));
+    }
+
+    @Override
+    public CompletableFuture<BotApiResponse> leaveRoom(final String roomId) {
+        return toFuture(retrofitImpl.leaveRoom(roomId));
+    }
+
+    private static <T> CompletableFuture<T> toFuture(Call<T> callToWrap) {
+        final CallbackAdaptor<T> completableFuture = new CallbackAdaptor<>();
+        callToWrap.enqueue(completableFuture);
+        return completableFuture;
+    }
+
+    private static CompletableFuture<MessageContentResponse> toMessageContentResponseFuture(
+            final Call<ResponseBody> callToWrap) {
+        final ResponseBodyCallbackAdaptor future = new ResponseBodyCallbackAdaptor();
+        callToWrap.enqueue(future);
+        return future;
+    }
+
+    static class CallbackAdaptor<T> extends CompletableFuture<T> implements Callback<T> {
+        @Override
+        public void onResponse(final Call<T> call, final Response<T> response) {
+            if (response.isSuccessful()) {
+                complete(response.body());
+            } else {
+                completeExceptionally(EXCEPTION_CONVERTER.apply(response));
+            }
+        }
+
+        @Override
+        public void onFailure(final Call<T> call, final Throwable t) {
+            completeExceptionally(
+                    new GeneralLineMessagingException(t.getMessage(), null, t));
+        }
+    }
+
+    static class ResponseBodyCallbackAdaptor
+            extends CompletableFuture<MessageContentResponse>
+            implements Callback<ResponseBody> {
+
+        @Override
+        public void onResponse(final Call<ResponseBody> call, final Response<ResponseBody> response) {
+            if (!response.isSuccessful()) {
+                completeExceptionally(EXCEPTION_CONVERTER.apply(response));
+                return;
+            }
+
+            try {
+                complete(convert(response));
+            } catch (RuntimeException exceptionInConvert) {
+                completeExceptionally(
+                        new GeneralLineMessagingException(exceptionInConvert.getMessage(),
+                                                          null, exceptionInConvert));
+            }
+        }
+
+        @Override
+        public void onFailure(final Call<ResponseBody> call, final Throwable t) {
+            completeExceptionally(
+                    new GeneralLineMessagingException(t.getMessage(), null, t));
+        }
+
+        private MessageContentResponse convert(final Response<ResponseBody> response) {
+            return MessageContentResponse
+                    .builder()
+                    .length(response.body().contentLength())
+                    .allHeaders(response.headers().toMultimap())
+                    .mimeType(response.body().contentType().toString())
+                    .stream(response.body().byteStream())
+                    .build();
+        }
+    }
+}

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/MessageContentResponse.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/MessageContentResponse.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class MessageContentResponse implements AutoCloseable {
+    /** File size of this content. */
+    final long length;
+
+    /** File input stream of this content. */
+    final InputStream stream;
+
+    /** File contents type represented by MIME. */
+    final String mimeType;
+
+    /** All HTTP headers of API response.
+     *
+     * Note: there are no SPEC for those headers.
+     * Current field values are provided AS-IS and can be changed/removed without announces.
+     */
+    final Map<String, List<String>> allHeaders;
+
+    @Override
+    public void close() throws IOException {
+        stream.close();
+    }
+}

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/BadRequestException.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/BadRequestException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client.exception;
+
+import com.linecorp.bot.model.error.ErrorResponse;
+
+public class BadRequestException extends LineMessagingException {
+    private static final long serialVersionUID = SERIAL_VERSION_UID;
+
+    public BadRequestException(
+            final String message,
+            final ErrorResponse errorResponse) {
+        super(message, errorResponse, null);
+    }
+}

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/ForbiddenException.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/ForbiddenException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client.exception;
+
+import com.linecorp.bot.model.error.ErrorResponse;
+
+public class ForbiddenException extends LineMessagingException {
+    private static final long serialVersionUID = SERIAL_VERSION_UID;
+
+    public ForbiddenException(
+            final String message,
+            final ErrorResponse errorResponse) {
+        super(message, errorResponse, null);
+    }
+}

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/GeneralLineMessagingException.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/GeneralLineMessagingException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client.exception;
+
+import com.linecorp.bot.model.error.ErrorResponse;
+
+/**
+ * General exceptions both in api server and SDK internal exceptions.
+ */
+public class GeneralLineMessagingException extends LineMessagingException {
+    private static final long serialVersionUID = SERIAL_VERSION_UID;
+
+    public GeneralLineMessagingException(
+            final String message, final ErrorResponse errorResponse, final Throwable cause) {
+        super(message, errorResponse, cause);
+    }
+}

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/LineMessagingException.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/LineMessagingException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client.exception;
+
+import com.linecorp.bot.model.error.ErrorResponse;
+
+import lombok.Getter;
+
+@Getter
+public abstract class LineMessagingException extends Exception {
+    static final long SERIAL_VERSION_UID = 0x001_003; // 1.3.x
+    private static final long serialVersionUID = SERIAL_VERSION_UID;
+
+    /**
+     * Original error response from server.
+     *
+     * Null when error response is not exist.
+     */
+    private final ErrorResponse errorResponse;
+
+    LineMessagingException(final String message, final ErrorResponse errorResponse,
+                           final Throwable cause) {
+        super(message, cause);
+        this.errorResponse = errorResponse;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + ", " + errorResponse;
+    }
+}

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/LineServerException.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/LineServerException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client.exception;
+
+import com.linecorp.bot.model.error.ErrorResponse;
+
+public class LineServerException extends LineMessagingException {
+    private static final long serialVersionUID = SERIAL_VERSION_UID;
+
+    public LineServerException(
+            final String message,
+            final ErrorResponse errorResponse) {
+        super(message, errorResponse, null);
+    }
+}

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/TooManyRequestsException.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/TooManyRequestsException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client.exception;
+
+import com.linecorp.bot.model.error.ErrorResponse;
+
+public class TooManyRequestsException extends LineMessagingException {
+    private static final long serialVersionUID = SERIAL_VERSION_UID;
+
+    public TooManyRequestsException(
+            final String message,
+            final ErrorResponse errorResponse) {
+        super(message, errorResponse, null);
+    }
+}

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/UnauthorizedException.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/UnauthorizedException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client.exception;
+
+import com.linecorp.bot.model.error.ErrorResponse;
+
+public class UnauthorizedException extends LineMessagingException {
+    private static final long serialVersionUID = SERIAL_VERSION_UID;
+
+    public UnauthorizedException(
+            final String message,
+            final ErrorResponse errorResponse) {
+        super(message, errorResponse, null);
+    }
+}

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/CallbackAdaptorTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/CallbackAdaptorTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import static okhttp3.MediaType.parse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.linecorp.bot.client.LineMessagingClientImpl.CallbackAdaptor;
+import com.linecorp.bot.client.exception.GeneralLineMessagingException;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Response;
+
+public class CallbackAdaptorTest {
+    private CallbackAdaptor<Object> target;
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Rule
+    public final Timeout timeoutRule = Timeout.seconds(1);
+
+    @Mock
+    private Call<Object> call;
+
+    @Before
+    public void setUp() throws Exception {
+        target = new CallbackAdaptor<>();
+    }
+
+    @Test
+    public void onResponseSuccessfullyTest() throws Exception {
+        final Object value = new Object();
+        Response<Object> response = Response.success(value);
+
+        // Do
+        target.onResponse(call, response);
+
+        // Verify
+        assertThat(target).isCompletedWithValue(value);
+    }
+
+    @Test
+    public void onResponseWithErrorTest() throws Exception {
+        Response<Object> response =
+                Response.error(400, ResponseBody.create(parse("application/json"), "{}"));
+
+        // Do
+        target.onResponse(call, response);
+
+        // Verify
+        assertThat(target).isCompletedExceptionally();
+    }
+
+    @Test
+    public void onFailureTest() throws Exception {
+        Throwable t = mock(Throwable.class);
+        when(t.getMessage()).thenReturn("Message");
+
+        // Do
+        target.onFailure(call, t);
+
+        // Verify
+        assertThat(target).isCompletedExceptionally();
+        assertThat(target.handle((ignored, e) -> e).get())
+                .isInstanceOf(GeneralLineMessagingException.class)
+                .withFailMessage("Message");
+    }
+}

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/ExceptionConverterTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/ExceptionConverterTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import com.linecorp.bot.client.exception.GeneralLineMessagingException;
+import com.linecorp.bot.client.exception.LineMessagingException;
+import com.linecorp.bot.client.exception.UnauthorizedException;
+
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+import retrofit2.Response;
+
+public class ExceptionConverterTest {
+    private final ExceptionConverter target = new ExceptionConverter();
+
+    @Test
+    public void convertTest() {
+        final ResponseBody responseBody =
+                ResponseBody.create(MediaType.parse("application/json"),
+                                    "{}");
+        final LineMessagingException result =
+                target.apply(Response.error(401, responseBody));
+
+        assertThat(result)
+                .isInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    public void convertUnknownExceptionTest() {
+        final ResponseBody responseBody =
+                ResponseBody.create(MediaType.parse("application/json"),
+                                    "{}");
+        final LineMessagingException result =
+                target.apply(Response.error(999, responseBody));
+
+        assertThat(result)
+                .isInstanceOf(GeneralLineMessagingException.class);
+    }
+
+    @Test
+    public void exceptionInConvertFallbackedTest() {
+        final ResponseBody responseBody = mock(ResponseBody.class);
+        when(responseBody.source()).thenThrow(new RuntimeException());
+
+        final LineMessagingException result =
+                target.apply(Response.error(401, responseBody));
+
+        assertThat(result)
+                .isInstanceOf(GeneralLineMessagingException.class);
+    }
+}

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.stubbing.OngoingStubbing;
+
+import com.linecorp.bot.model.PushMessage;
+import com.linecorp.bot.model.ReplyMessage;
+import com.linecorp.bot.model.message.TextMessage;
+import com.linecorp.bot.model.profile.UserProfileResponse;
+import com.linecorp.bot.model.response.BotApiResponse;
+
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class LineMessagingClientImplTest {
+    private static final byte[] ZERO_BYTES = {};
+    private static final BotApiResponse BOT_API_SUCCESS_RESPONSE = new BotApiResponse("sucess", emptyList());
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Rule
+    public final Timeout timeoutRule = Timeout.seconds(1);
+
+    @Mock
+    private LineMessagingService retrofitMock;
+
+    @InjectMocks
+    private LineMessagingClientImpl target;
+
+    @Test
+    public void replyMessageTest() throws Exception {
+        whenCall(retrofitMock.replyMessage(any()),
+                 BOT_API_SUCCESS_RESPONSE);
+        final ReplyMessage replyMessage = new ReplyMessage("token", new TextMessage("Message"));
+
+        // Do
+        final BotApiResponse botApiResponse =
+                target.replyMessage(replyMessage).get();
+
+        // Verify
+        verify(retrofitMock, only()).replyMessage(replyMessage);
+        assertThat(botApiResponse).isEqualTo(BOT_API_SUCCESS_RESPONSE);
+    }
+
+    @Test
+    public void pushMessageTest() throws Exception {
+        whenCall(retrofitMock.pushMessage(any()),
+                 BOT_API_SUCCESS_RESPONSE);
+        final PushMessage pushMessage = new PushMessage("TO", new TextMessage("text"));
+
+        // Do
+        final BotApiResponse botApiResponse =
+                target.pushMessage(pushMessage).get();
+
+        // Verify
+        verify(retrofitMock, only()).pushMessage(pushMessage);
+        assertThat(botApiResponse).isEqualTo(BOT_API_SUCCESS_RESPONSE);
+    }
+
+    @Test
+    public void getMessageContentTest() throws Exception {
+        whenCall(retrofitMock.getMessageContent(any()),
+                 ResponseBody.create(MediaType.parse("image/jpeg"), ZERO_BYTES));
+
+        // Do
+        final MessageContentResponse contentResponse = target.getMessageContent("ID").get();
+
+        // Verify
+        verify(retrofitMock, only()).getMessageContent("ID");
+        assertThat(contentResponse.getLength()).isEqualTo(0);
+        assertThat(contentResponse.getMimeType()).isEqualTo("image/jpeg");
+    }
+
+    @Test
+    public void getProfileTest() throws Exception {
+        final UserProfileResponse mockUserProfileResponse =
+                new UserProfileResponse("displayName", "userId", "pictureUrl", "statusMessage");
+        whenCall(retrofitMock.getProfile(any()),
+                 mockUserProfileResponse);
+
+        // Do
+        final UserProfileResponse response = target.getProfile("USER_ID").get();
+
+        // Verify
+        verify(retrofitMock, only()).getProfile("USER_ID");
+        assertThat(response).isEqualTo(mockUserProfileResponse);
+    }
+
+    @Test
+    public void leaveGroupTest() throws Exception {
+        whenCall(retrofitMock.leaveGroup(any()),
+                 BOT_API_SUCCESS_RESPONSE);
+
+        // Do
+        final BotApiResponse botApiResponse = target.leaveGroup("ID").get();
+
+        // Verify
+        verify(retrofitMock, only()).leaveGroup("ID");
+        assertThat(botApiResponse).isEqualTo(BOT_API_SUCCESS_RESPONSE);
+    }
+
+    @Test
+    public void leaveRoomTest() throws Exception {
+        whenCall(retrofitMock.leaveRoom(any()),
+                 BOT_API_SUCCESS_RESPONSE);
+
+        // Do
+        final BotApiResponse botApiResponse = target.leaveRoom("ID").get();
+
+        // Verify
+        verify(retrofitMock, only()).leaveRoom("ID");
+        assertThat(botApiResponse).isEqualTo(BOT_API_SUCCESS_RESPONSE);
+    }
+
+    // Utility methods
+
+    private static <T> void whenCall(Call<T> call, T value) {
+        final OngoingStubbing<Call<T>> callOngoingStubbing = when(call);
+        callOngoingStubbing.thenReturn(enqueue(value));
+    }
+
+    private static <T> Call<T> enqueue(T value) {
+        return new Call<T>() {
+            @Override
+            public Response<T> execute() throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void enqueue(Callback<T> callback) {
+                callback.onResponse(this, Response.success(value));
+            }
+
+            @Override
+            public boolean isExecuted() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void cancel() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isCanceled() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Call<T> clone() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Request request() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplWiremockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplWiremockTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hamcrest.CoreMatchers.isA;
+
+import java.util.concurrent.ExecutionException;
+
+import org.hamcrest.CustomTypeSafeMatcher;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import com.linecorp.bot.client.exception.BadRequestException;
+import com.linecorp.bot.client.exception.ForbiddenException;
+import com.linecorp.bot.client.exception.LineMessagingException;
+import com.linecorp.bot.client.exception.LineServerException;
+import com.linecorp.bot.client.exception.TooManyRequestsException;
+import com.linecorp.bot.client.exception.UnauthorizedException;
+import com.linecorp.bot.model.error.ErrorResponse;
+
+import lombok.SneakyThrows;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+public class LineMessagingClientImplWiremockTest {
+    static {
+        SLF4JBridgeHandler.install();
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+    }
+
+    private static final ObjectWriter ERROR_RESPONSE_READER = new ObjectMapper().writerFor(ErrorResponse.class);
+    private static final int ASYNC_TEST_TIMEOUT = 1_000;
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    private MockWebServer mockWebServer;
+    private LineMessagingClient lineMessagingClient;
+
+    @Before
+    public void setUp() {
+        mockWebServer = new MockWebServer();
+        LineMessagingService lineMessagingService =
+                LineMessagingServiceBuilder.create("token")
+                                           .apiEndPoint("http://localhost:" + mockWebServer.getPort())
+                                           .build();
+        lineMessagingClient = new LineMessagingClientImpl(lineMessagingService);
+    }
+
+    @After
+    public void shutDown() throws Exception {
+        mockWebServer.shutdown();
+    }
+
+    @Test(timeout = ASYNC_TEST_TIMEOUT)
+    public void status400BadRequestTest() throws Exception {
+        final ErrorResponse errorResponse =
+                new ErrorResponse("Problem with the request", null);
+
+        // Mocking
+        mocking(400, errorResponse);
+
+        // Expect
+        expectedException.expect(ExecutionException.class);
+        expectedException.expectCause(isA(BadRequestException.class));
+        expectedException.expectCause(errorResponseIs(errorResponse));
+
+        // Do
+        lineMessagingClient.getMessageContent("TOKEN").get();
+    }
+
+    @Test(timeout = ASYNC_TEST_TIMEOUT)
+    public void status401UnauthorizedTest() throws Exception {
+        final ErrorResponse errorResponse =
+                new ErrorResponse("Valid Channel access token is not specified", null);
+
+        // Mocking
+        mocking(401, errorResponse);
+
+        // Expect
+        expectedException.expect(ExecutionException.class);
+        expectedException.expectCause(isA(UnauthorizedException.class));
+        expectedException.expectCause(errorResponseIs(errorResponse));
+
+        // Do
+        lineMessagingClient.getMessageContent("TOKEN").get();
+    }
+
+    @Test(timeout = ASYNC_TEST_TIMEOUT)
+    public void status403ForbiddenTest() throws Exception {
+        final ErrorResponse errorResponse =
+                new ErrorResponse("Not authorized to use the API.", null);
+
+        // Mocking
+        mocking(403, errorResponse);
+
+        // Expect
+        expectedException.expect(ExecutionException.class);
+        expectedException.expectCause(isA(ForbiddenException.class));
+        expectedException.expectCause(errorResponseIs(errorResponse));
+
+        // Do
+        lineMessagingClient.getMessageContent("TOKEN").get();
+    }
+
+    @Test(timeout = ASYNC_TEST_TIMEOUT)
+    public void status429TooManyRequestsTest() throws Exception {
+        final ErrorResponse errorResponse =
+                new ErrorResponse("Exceeded the rate limit for API calls", null);
+
+        // Mocking
+        mocking(429, errorResponse);
+
+        // Expect
+        expectedException.expect(ExecutionException.class);
+        expectedException.expectCause(isA(TooManyRequestsException.class));
+        expectedException.expectCause(errorResponseIs(errorResponse));
+
+        // Do
+        lineMessagingClient.getMessageContent("TOKEN").get();
+    }
+
+    @Test(timeout = ASYNC_TEST_TIMEOUT)
+    public void status500InternalServerErrorTest() throws Exception {
+        final ErrorResponse errorResponse =
+                new ErrorResponse("Error on the internal server", null);
+
+        // Mocking
+        mocking(500, errorResponse);
+
+        // Expect
+        expectedException.expect(ExecutionException.class);
+        expectedException.expectCause(isA(LineServerException.class));
+        expectedException.expectCause(errorResponseIs(errorResponse));
+
+        // Do
+        lineMessagingClient.getMessageContent("TOKEN").get();
+    }
+
+    @SneakyThrows
+    private void mocking(final int responseCode, final ErrorResponse errorResponse) {
+        mockWebServer
+                .enqueue(new MockResponse()
+                                 .setResponseCode(responseCode)
+                                 .setBody(ERROR_RESPONSE_READER.writeValueAsString(errorResponse)));
+    }
+
+    private CustomTypeSafeMatcher<LineMessagingException> errorResponseIs(final ErrorResponse errorResponse) {
+        return new CustomTypeSafeMatcher<LineMessagingException>("Error Response") {
+            @Override
+            protected boolean matchesSafely(LineMessagingException item) {
+                assertThat(item.getErrorResponse())
+                        .isEqualTo(errorResponse);
+
+                return true;
+            }
+        };
+    }
+}

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/ResponseBodyCallbackAdaptorTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/ResponseBodyCallbackAdaptorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.linecorp.bot.client.LineMessagingClientImpl.ResponseBodyCallbackAdaptor;
+import com.linecorp.bot.client.exception.GeneralLineMessagingException;
+import com.linecorp.bot.client.exception.UnauthorizedException;
+
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Response;
+
+public class ResponseBodyCallbackAdaptorTest {
+    private ResponseBodyCallbackAdaptor target;
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Rule
+    public final Timeout timeoutRule = Timeout.seconds(1);
+
+    @Mock
+    private Call<ResponseBody> call;
+
+    @Before
+    public void setUp() throws Exception {
+        target = new ResponseBodyCallbackAdaptor();
+    }
+
+    @Test
+    public void onResponseSuccessTest() throws Exception {
+        Response<ResponseBody> response =
+                Response.success(ResponseBody.create(MediaType.parse("image/jpeg"),
+                                                     ""));
+
+        // Do
+        target.onResponse(call, response);
+
+        // Verify
+        assertThat(target).isCompleted();
+        final MessageContentResponse messageContentResponse = target.get();
+        assertThat(messageContentResponse.getLength()).isEqualTo(0);
+        assertThat(messageContentResponse.getStream())
+                .hasSameContentAs(new ByteArrayInputStream(new byte[] {}));
+        assertThat(messageContentResponse.getAllHeaders())
+                .isEmpty();
+    }
+
+    @Test
+    public void onResponseFailTest() throws Exception {
+        Response<ResponseBody> response =
+                Response.error(401, ResponseBody.create(MediaType.parse("text/javascript"),
+                                                        "{}"));
+
+        // Do
+        target.onResponse(call, response);
+
+        // Verify
+        assertThat(target).isCompletedExceptionally();
+
+        final Throwable t = target.handle((ignored, e) -> e).get();
+        assertThat(t).isInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    public void onFailureTest() throws Exception {
+        IOException t = mock(IOException.class);
+        when(t.getMessage()).thenReturn("ResponseBodyCallbackAdaptorTest Failed");
+
+        // Do
+        target.onFailure(call, t);
+
+        // Verify
+        assertThat(target).isCompletedExceptionally();
+        assertThat(target.handle((ignored, e) -> e).get())
+                .isInstanceOf(GeneralLineMessagingException.class)
+                .withFailMessage("ResponseBodyCallbackAdaptorTest Failed");
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/error/ErrorDetail.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/error/ErrorDetail.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.error;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Value;
+
+@Value
+public class ErrorDetail {
+    /** Details of the error */
+    String message;
+
+    /** Position of the error occurred */
+    String property;
+
+    public ErrorDetail(
+            @JsonProperty("message") String message,
+            @JsonProperty("property") String property) {
+        this.message = message;
+        this.property = property;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/error/ErrorResponse.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/error/ErrorResponse.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.error;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Value;
+
+/**
+ * Error response from LINE Messaging Server.
+ *
+ * @see <a href="https://devdocs.line.me/#error-response">//devdocs.line.me/#error-response</a>
+ */
+@Value
+public class ErrorResponse {
+    /** Summary or details of the error. */
+    String message;
+
+    /**
+     * Details of the error.
+     *
+     * In this class, always non-null but can be empty.
+     */
+    List<ErrorDetail> details;
+
+    public ErrorResponse(
+            @JsonProperty("message") final String message,
+            @JsonProperty("details") final List<ErrorDetail> details) {
+        this.message = message;
+        this.details = details != null ? details : Collections.emptyList();
+    }
+}

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/error/ErrorResponseTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/error/ErrorResponseTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.error;
+
+import static java.lang.ClassLoader.getSystemResourceAsStream;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ErrorResponseTest {
+    @Test
+    public void simpleErrorResponseTest() throws IOException {
+        // Do
+        final ErrorResponse result = new ObjectMapper()
+                .readValue(getSystemResourceAsStream("error/error401.json"),
+                           ErrorResponse.class);
+
+        // Verify
+        assertThat(result.getMessage()).contains("Authentication failed");
+        assertThat(result.getDetails()).isNotNull().isEmpty();
+    }
+
+    @Test
+    public void complexErrorResponseTest() throws IOException {
+        // Do
+        final ErrorResponse result = new ObjectMapper()
+                .readValue(getSystemResourceAsStream("error/error_with_detail.json"),
+                           ErrorResponse.class);
+
+        // Verify
+        assertThat(result.getMessage()).isEqualTo("The request body has 2 error(s)");
+        assertThat(result.getDetails()).containsExactly(
+                new ErrorDetail("May not be empty",
+                                "messages[0].text"),
+                new ErrorDetail("Must be one of the following values: " +
+                                "[text, image, video, audio, location, sticker, richmessage, template, imagemap]",
+                                "messages[1].type"));
+    }
+}

--- a/line-bot-model/src/test/resources/error/error401.json
+++ b/line-bot-model/src/test/resources/error/error401.json
@@ -1,0 +1,3 @@
+{
+  "message": "Authentication failed due to the following reason: invalid token. Confirm that the access token in the authorization header is valid."
+}

--- a/line-bot-model/src/test/resources/error/error_with_detail.json
+++ b/line-bot-model/src/test/resources/error/error_with_detail.json
@@ -1,0 +1,10 @@
+{
+  "message": "The request body has 2 error(s)",
+  "details": [
+    { "message": "May not be empty", "property": "messages[0].text" },
+    {
+      "message": "Must be one of the following values: [text, image, video, audio, location, sticker, richmessage, template, imagemap]",
+      "property": "messages[1].type"
+    }
+  ]
+}

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotAutoConfiguration.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotAutoConfiguration.java
@@ -26,6 +26,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import com.linecorp.bot.client.LineMessagingClient;
+import com.linecorp.bot.client.LineMessagingClientImpl;
 import com.linecorp.bot.client.LineMessagingService;
 import com.linecorp.bot.client.LineMessagingServiceBuilder;
 import com.linecorp.bot.client.LineSignatureValidator;
@@ -51,6 +53,11 @@ public class LineBotAutoConfiguration {
                 .readTimeout(lineBotProperties.getReadTimeout())
                 .writeTimeout(lineBotProperties.getWriteTimeout())
                 .build();
+    }
+
+    @Bean
+    public LineMessagingClient lineMessagingClient(final LineMessagingService lineMessagingService) {
+        return new LineMessagingClientImpl(lineMessagingService);
     }
 
     @Bean

--- a/sample-spring-boot-echo/src/main/java/com/example/bot/spring/echo/EchoApplication.java
+++ b/sample-spring-boot-echo/src/main/java/com/example/bot/spring/echo/EchoApplication.java
@@ -22,7 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-import com.linecorp.bot.client.LineMessagingService;
+import com.linecorp.bot.client.LineMessagingClient;
 import com.linecorp.bot.model.ReplyMessage;
 import com.linecorp.bot.model.event.Event;
 import com.linecorp.bot.model.event.MessageEvent;
@@ -36,7 +36,7 @@ import com.linecorp.bot.spring.boot.annotation.LineMessageHandler;
 @LineMessageHandler
 public class EchoApplication {
     @Autowired
-    private LineMessagingService lineMessagingService;
+    private LineMessagingClient lineMessagingClient;
 
     public static void main(String[] args) {
         SpringApplication.run(EchoApplication.class, args);
@@ -45,10 +45,10 @@ public class EchoApplication {
     @EventMapping
     public void handleTextMessageEvent(MessageEvent<TextMessageContent> event) throws Exception {
         System.out.println("event: " + event);
-        final BotApiResponse apiResponse = lineMessagingService
+        final BotApiResponse apiResponse = lineMessagingClient
                 .replyMessage(new ReplyMessage(event.getReplyToken(),
                                                singletonList(new TextMessage(event.getMessage().getText()))))
-                .execute().body();
+                .get();
         System.out.println("Sent messages: " + apiResponse);
     }
 


### PR DESCRIPTION
* Add LineMessagingClient.java
* Add Exception class such as LineMessagingException.java

## Motivation
- Use Java8's standard async mechanism.
- Don't open implementation detail of LineMessagingClient.
  - Remove retrofit dependency from SDK outside.

This PR close https://github.com/line/line-bot-sdk-java/issues/47.
