### PR TITLE
Fix compiler warnings.

### DIFF
--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupport.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupport.java
@@ -106,7 +106,7 @@ public class LineMessageHandlerSupport {
 
         Preconditions.checkState(method.getParameterCount() == 1,
                                  "Number of parameter should be 1. But {}",
-                                 method.getParameterTypes());
+                                 (Object[]) method.getParameterTypes());
         // TODO: Support more than 1 argument. Like MVC's argument resolver?
 
         final Type type = method.getGenericParameterTypes()[0];


### PR DESCRIPTION
Cleanup for release.

```
~/github.com/line/line-bot-sdk-java-v2/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupport.java:109: 警告: 最終パラメータの不正確な引数型を持った可変引数メソッドの非可変引数呼出し。
                                 method.getParameterTypes());
                                                         ^
  可変引数呼出しに関してはObjectにキャストします。
  非可変引数呼出しに関してはObject[]にキャストしてこの警告を出さないようにします
```