### PR TITLE
Add ErrorResponse class.

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/error/ErrorDetail.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/error/ErrorDetail.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.error;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Value;
+
+@Value
+public class ErrorDetail {
+    /** Details of the error */
+    String message;
+
+    /** Position of the error occurred */
+    String property;
+
+    public ErrorDetail(
+            @JsonProperty("message") String message,
+            @JsonProperty("property") String property) {
+        this.message = message;
+        this.property = property;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/error/ErrorResponse.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/error/ErrorResponse.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.error;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Value;
+
+/**
+ * Error response from LINE Messaging Server.
+ *
+ * @see <a href="https://devdocs.line.me/#error-response">//devdocs.line.me/#error-response</a>
+ */
+@Value
+public class ErrorResponse {
+    /** Summary or details of the error. */
+    String message;
+
+    /**
+     * Details of the error.
+     *
+     * In this class, always non-null but can be empty.
+     */
+    List<ErrorDetail> details;
+
+    public ErrorResponse(
+            @JsonProperty("message") final String message,
+            @JsonProperty("details") final List<ErrorDetail> details) {
+        this.message = message;
+        this.details = details != null ? details : Collections.emptyList();
+    }
+}

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/error/ErrorResponseTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/error/ErrorResponseTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.error;
+
+import static java.lang.ClassLoader.getSystemResourceAsStream;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ErrorResponseTest {
+    @Test
+    public void simpleErrorResponseTest() throws IOException {
+        // Do
+        final ErrorResponse result = new ObjectMapper()
+                .readValue(getSystemResourceAsStream("error/error401.json"),
+                           ErrorResponse.class);
+
+        // Verify
+        assertThat(result.getMessage()).contains("Authentication failed");
+        assertThat(result.getDetails()).isNotNull().isEmpty();
+    }
+
+    @Test
+    public void complexErrorResponseTest() throws IOException {
+        // Do
+        final ErrorResponse result = new ObjectMapper()
+                .readValue(getSystemResourceAsStream("error/error_with_detail.json"),
+                           ErrorResponse.class);
+
+        // Verify
+        assertThat(result.getMessage()).isEqualTo("The request body has 2 error(s)");
+        assertThat(result.getDetails()).containsExactly(
+                new ErrorDetail("May not be empty",
+                                "messages[0].text"),
+                new ErrorDetail("Must be one of the following values: " +
+                                "[text, image, video, audio, location, sticker, richmessage, template, imagemap]",
+                                "messages[1].type"));
+    }
+}

--- a/line-bot-model/src/test/resources/error/error401.json
+++ b/line-bot-model/src/test/resources/error/error401.json
@@ -1,0 +1,3 @@
+{
+  "message": "Authentication failed due to the following reason: invalid token. Confirm that the access token in the authorization header is valid."
+}

--- a/line-bot-model/src/test/resources/error/error_with_detail.json
+++ b/line-bot-model/src/test/resources/error/error_with_detail.json
@@ -1,0 +1,10 @@
+{
+  "message": "The request body has 2 error(s)",
+  "details": [
+    { "message": "May not be empty", "property": "messages[0].text" },
+    {
+      "message": "Must be one of the following values: [text, image, video, audio, location, sticker, richmessage, template, imagemap]",
+      "property": "messages[1].type"
+    }
+  ]
+}


### PR DESCRIPTION
Add ErrorResponse. corresponding https://github.com/line/line-bot-sdk-java/issues/51.

This structure is documented in https://devdocs.line-beta.me/#error-response

(Will be used in / divided from https://github.com/line/line-bot-sdk-java/pull/46 )