### PR TITLE
Make annotation URL relative from endpoint.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ subprojects {
         testCompile 'com.squareup.okhttp3:mockwebserver'
         testCompile 'org.hibernate:hibernate-validator'
         testCompile 'org.springframework.boot:spring-boot-starter-test' // MockHttpServletRequest
-        testRuntime 'org.springframework.boot:spring-boot-starter-logging'
+        testCompile 'org.springframework.boot:spring-boot-starter-logging'
     }
 
     compileJava.dependsOn(processResources) // http://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html#configuration-metadata-annotation-processor

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingService.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingService.java
@@ -41,7 +41,7 @@ public interface LineMessagingService {
      * @see #pushMessage(PushMessage)
      * @see <a href="https://devdocs.line.me?java#reply-message">//devdocs.line.me#reply-message</a>
      */
-    @POST("/v2/bot/message/reply")
+    @POST("v2/bot/message/reply")
     Call<BotApiResponse> replyMessage(@Body ReplyMessage replyMessage);
 
     /**
@@ -52,7 +52,7 @@ public interface LineMessagingService {
      * @see #replyMessage(ReplyMessage)
      * @see <a href="https://devdocs.line.me?java#push-message">//devdocs.line.me#push-message</a>
      */
-    @POST("/v2/bot/message/push")
+    @POST("v2/bot/message/push")
     Call<BotApiResponse> pushMessage(@Body PushMessage pushMessage);
 
     /**
@@ -61,7 +61,7 @@ public interface LineMessagingService {
      * @see <a href="https://devdocs.line.me?java#get-content">//devdocs.line.me#get-content</a>
      */
     @Streaming
-    @GET("/v2/bot/message/{messageId}/content")
+    @GET("v2/bot/message/{messageId}/content")
     Call<ResponseBody> getMessageContent(@Path("messageId") String messageId);
 
     /**
@@ -69,7 +69,7 @@ public interface LineMessagingService {
      *
      * @see <a href="https://devdocs.line.me?java#bot-api-get-profile">//devdocs.line.me#bot-api-get-profile</a>
      */
-    @GET("/v2/bot/profile/{userId}")
+    @GET("v2/bot/profile/{userId}")
     Call<UserProfileResponse> getProfile(@Path("userId") String userId);
 
     /**
@@ -77,7 +77,7 @@ public interface LineMessagingService {
      *
      * @see <a href="https://devdocs.line.me?java#leave">//devdocs.line.me#leave</a>
      */
-    @POST("/v2/bot/group/{groupId}/leave")
+    @POST("v2/bot/group/{groupId}/leave")
     Call<BotApiResponse> leaveGroup(@Path("groupId") String groupId);
 
     /**
@@ -85,6 +85,6 @@ public interface LineMessagingService {
      *
      * @see <a href="https://devdocs.line.me?java#leave">//devdocs.line.me#leave</a>
      */
-    @POST("/v2/bot/room/{roomId}/leave")
+    @POST("v2/bot/room/{roomId}/leave")
     Call<BotApiResponse> leaveRoom(@Path("roomId") String roomId);
 }

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingServiceTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingServiceTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.linecorp.bot.model.profile.UserProfileResponse;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+public class LineMessagingServiceTest {
+    static {
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+    }
+
+    private MockWebServer mockWebServer;
+    private LineMessagingService target;
+
+    @Before
+    public void setUp() throws Exception {
+        mockWebServer = new MockWebServer();
+        final String apiEndPoint =
+                "http://" + mockWebServer.getHostName() + ':' + mockWebServer.getPort() +
+                "/CanContainsRelative/";
+        target = LineMessagingServiceBuilder
+                .create("SECRET")
+                .apiEndPoint(apiEndPoint)
+                .build();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    public void relativeRequestTest() throws Exception {
+        final UserProfileResponse profileResponseMock =
+                new UserProfileResponse("name", "userId",
+                                        "https://line.me/picture_url",
+                                        "Status message");
+
+        mockWebServer.enqueue(new MockResponse()
+                                      .setResponseCode(200)
+                                      .setBody(new ObjectMapper()
+                                                       .writeValueAsString(profileResponseMock)));
+
+        // Do
+        final UserProfileResponse actualResponse =
+                target.getProfile("USER_TOKEN").execute().body();
+
+        // Verify
+        final RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        assertThat(recordedRequest.getPath())
+                .isEqualTo("/CanContainsRelative/v2/bot/profile/USER_TOKEN");
+        assertThat(actualResponse).isEqualTo(profileResponseMock);
+    }
+}


### PR DESCRIPTION
If we set path (string start with "/"), path of baseurl is ignored.
This is important for users who accessing api.line.me via http reverse proxy.

* `/v2/bot/xxx` resolved on `http://company-http-proxy/api-line-me/` is\
 `http://ourcompany-http-proxy/v2/bot/xxx` (NG)
* `v2/bot/xxx` resolved on `http://company-http-proxy/api-line-me/` is\
 `http://ourcompany-http-proxy/api-line-me/v2/bot/xxx` (OK)