### PR TITLE
Add feature: Reply message by SDK from @EventHandler method return value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,42 +47,33 @@ package com.example.bot.spring.echo;
 
 import static java.util.Collections.singletonList;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.List;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-import com.linecorp.bot.client.LineMessagingClient;
-import com.linecorp.bot.model.ReplyMessage;
 import com.linecorp.bot.model.event.Event;
 import com.linecorp.bot.model.event.MessageEvent;
 import com.linecorp.bot.model.event.message.TextMessageContent;
 import com.linecorp.bot.model.message.TextMessage;
-import com.linecorp.bot.model.response.BotApiResponse;
 import com.linecorp.bot.spring.boot.annotation.EventMapping;
 import com.linecorp.bot.spring.boot.annotation.LineMessageHandler;
 
 @SpringBootApplication
 @LineMessageHandler
 public class EchoApplication {
-    @Autowired
-    private LineMessagingClient lineMessagingClient;
-
     public static void main(String[] args) {
         SpringApplication.run(EchoApplication.class, args);
     }
 
     @EventMapping
-    public void handleTextMessageEvent(MessageEvent<TextMessageContent> event) throws Exception {
+    public List<TextMessage> handleTextMessageEvent(MessageEvent<TextMessageContent> event) throws Exception {
         System.out.println("event: " + event);
-        final BotApiResponse apiResponse = lineMessagingClient
-                .replyMessage(new ReplyMessage(event.getReplyToken(),
-                                               singletonList(new TextMessage(event.getMessage().getText()))))
-                .get();
-        System.out.println("Sent messages: " + apiResponse);
+        return singletonList(new TextMessage(event.getMessage().getText()));
     }
 
     @EventMapping
-    public void defaultMessageEvent(Event event) {
+    public void handleDefaultMessageEvent(Event event) {
         System.out.println("event: " + event);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ subprojects {
             dependency 'com.squareup.retrofit2:converter-jackson:2.1.0'
             dependency 'com.squareup.retrofit2:retrofit:2.1.0'
             dependency 'org.assertj:assertj-core:3.5.2' // Update from 2.5.0 (by Spring-Boot and Spring IO)
+            dependency 'com.github.stefanbirkner:system-rules:1.16.1'
         }
     }
 
@@ -99,6 +100,7 @@ subprojects {
         compileOnly "org.springframework.boot:spring-boot-configuration-processor" // http://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html#configuration-metadata-annotation-processor
 
         testCompile 'com.google.guava:guava'
+        testCompile 'com.github.stefanbirkner:system-rules'
         testCompile 'com.squareup.okhttp3:mockwebserver'
         testCompile 'org.hibernate:hibernate-validator'
         testCompile 'org.springframework.boot:spring-boot-starter-test' // MockHttpServletRequest

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/BeaconEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/BeaconEvent.java
@@ -32,7 +32,7 @@ import lombok.Value;
  */
 @Value
 @JsonTypeName("beacon")
-public class BeaconEvent implements Event {
+public class BeaconEvent implements Event.ReplySupport {
     /**
      * Token for replying to this event
      */

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/Event.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/Event.java
@@ -52,4 +52,8 @@ public interface Event {
      * Time of the event
      */
     Instant getTimestamp();
+
+    interface ReplySupport extends Event {
+        String getReplyToken();
+    }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/FollowEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/FollowEvent.java
@@ -31,7 +31,7 @@ import lombok.Value;
  */
 @Value
 @JsonTypeName("follow")
-public class FollowEvent implements Event {
+public class FollowEvent implements Event.ReplySupport {
     /**
      * Token for replying to this event
      */

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/JoinEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/JoinEvent.java
@@ -31,7 +31,7 @@ import lombok.Value;
  */
 @Value
 @JsonTypeName("join")
-public class JoinEvent implements Event {
+public class JoinEvent implements Event.ReplySupport {
     /**
      * Token for replying to this event
      */

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/MessageEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/MessageEvent.java
@@ -33,7 +33,7 @@ import lombok.Value;
  */
 @Value
 @JsonTypeName("message")
-public class MessageEvent<T extends MessageContent> implements Event {
+public class MessageEvent<T extends MessageContent> implements Event.ReplySupport {
     /**
      * Token for replying to this event
      */

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/PostbackEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/PostbackEvent.java
@@ -32,7 +32,7 @@ import lombok.Value;
  */
 @Value
 @JsonTypeName("postback")
-public class PostbackEvent implements Event {
+public class PostbackEvent implements Event.ReplySupport {
     /**
      * Token for replying to this event
      */

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/event/ReplySupportTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/event/ReplySupportTest.java
@@ -1,0 +1,55 @@
+package com.linecorp.bot.model.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.util.ClassUtils;
+
+import com.google.common.base.Preconditions;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ReplySupportTest {
+    @Test
+    @SuppressWarnings("unchecked")
+    public void eventWithReplyTokenShouldBeImplementReplySupportTest() {
+        ClassPathScanningCandidateComponentProvider scanningProvider =
+                new ClassPathScanningCandidateComponentProvider(false);
+        scanningProvider
+                .addIncludeFilter((metadataReader, metadataReaderFactory) -> true);
+
+        final Set<Class<?>> eventClasses =
+                scanningProvider.findCandidateComponents(Event.class.getPackage().getName())
+                                .stream()
+                                .map(BeanDefinition::getBeanClassName)
+                                .map(className -> {
+                                    try {
+                                        return (Class<?>) Class.forName(className);
+                                    } catch (ClassNotFoundException e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                })
+                                .filter(Event.class::isAssignableFrom)
+                                .collect(Collectors.toSet());
+
+        log.info("eventClasses = {}", eventClasses);
+
+        Preconditions.checkState(!eventClasses.isEmpty(),
+                                 "Event classes scan result are empty Scanning bug.");
+
+        for (Class<?> eventClass : eventClasses) {
+            final boolean hasReplyTokenMethod = ClassUtils.hasMethod(eventClass, "getReplyToken");
+
+            if (hasReplyTokenMethod) {
+                assertThat(Event.ReplySupport.class)
+                        .isAssignableFrom(eventClass);
+            }
+        }
+    }
+}

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupport.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupport.java
@@ -155,7 +155,7 @@ public class LineMessageHandlerSupport {
     }
 
     @Value
-    public static class HandlerMethod {
+    static class HandlerMethod {
         Predicate<Event> supportType;
         Object object;
         Method handler;

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/ReplyByReturnValueConsumer.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/ReplyByReturnValueConsumer.java
@@ -1,0 +1,116 @@
+package com.linecorp.bot.spring.boot.support;
+
+import static java.util.Collections.singletonList;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+import com.linecorp.bot.client.LineMessagingClient;
+import com.linecorp.bot.model.ReplyMessage;
+import com.linecorp.bot.model.event.Event;
+import com.linecorp.bot.model.event.Event.ReplySupport;
+import com.linecorp.bot.model.message.Message;
+import com.linecorp.bot.model.response.BotApiResponse;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Internal class to send message as reply.
+ *
+ * Basically, message contents are from return value of handler method.
+ *
+ * @see LineMessageHandlerSupport#handleReturnValue(Event, Object)
+ */
+@Slf4j
+@Builder
+class ReplyByReturnValueConsumer implements Consumer<Object> {
+    private final LineMessagingClient lineMessagingClient;
+    private final Event originalEvent;
+
+    @Component
+    @AllArgsConstructor(onConstructor = @__(@Autowired))
+    public static class Factory {
+        private final LineMessagingClient lineMessagingClient;
+
+        ReplyByReturnValueConsumer createForEvent(final Event event) {
+            return builder()
+                    .lineMessagingClient(lineMessagingClient)
+                    .originalEvent(event)
+                    .build();
+        }
+    }
+
+    @Override
+    public void accept(final Object returnValue) {
+        if (returnValue instanceof CompletableFuture) {
+            // accept when future complete.
+            ((CompletableFuture<?>) returnValue)
+                    .whenComplete(this::whenComplete);
+        } else {
+            // accept immediately.
+            acceptResult(returnValue);
+        }
+    }
+
+    private void whenComplete(final Object futureResult, final Throwable throwable) {
+        if (throwable != null) {
+            log.error("Method return value waited but exception occurred in CompletedFuture", throwable);
+            return;
+        }
+
+        acceptResult(futureResult);
+    }
+
+    private void acceptResult(final Object returnValue) {
+        if (returnValue instanceof Message) {
+            reply(singletonList((Message) returnValue));
+        } else if (returnValue instanceof List) {
+            List<?> returnValueAsList = (List<?>) returnValue;
+
+            if (returnValueAsList.isEmpty()) {
+                return;
+            }
+
+            reply(checkListContents(returnValueAsList));
+        }
+    }
+
+    private void reply(final List<Message> messages) {
+        final Event.ReplySupport event = (ReplySupport) originalEvent;
+        lineMessagingClient.replyMessage(new ReplyMessage(event.getReplyToken(), messages))
+                           .whenComplete(this::logging);
+        // DO NOT BLOCK HERE, otherwise, next message processing will be BLOCKED.
+    }
+
+    private void logging(final BotApiResponse botApiResponse, final Throwable throwable) {
+        if (throwable == null) {
+            log.debug("Reply message success. response = {}", botApiResponse);
+        } else {
+            log.warn("Reply message failed: {}", throwable.getMessage(), throwable);
+        }
+    }
+
+    @VisibleForTesting
+    static List<Message> checkListContents(final List<?> list) {
+        for (int i = 0; i < list.size(); ++i) {
+            final Object item = list.get(i);
+            Preconditions.checkNotNull(item, "item is null. index = {} in {}", i, list);
+            Preconditions.checkArgument(item instanceof Message,
+                                        "List contains not Message type object. type = {}",
+                                        item.getClass());
+        }
+
+        @SuppressWarnings("unchecked")
+        final List<Message> messageList = (List<Message>) list;
+        return messageList;
+    }
+}

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupportTest.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupportTest.java
@@ -18,11 +18,15 @@ package com.linecorp.bot.spring.boot.support;
 
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
 import java.util.function.Predicate;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -36,9 +40,13 @@ import com.google.common.collect.ImmutableMap;
 import com.linecorp.bot.model.event.Event;
 import com.linecorp.bot.model.event.MessageEvent;
 import com.linecorp.bot.model.event.message.TextMessageContent;
+import com.linecorp.bot.model.message.TextMessage;
 import com.linecorp.bot.spring.boot.annotation.EventMapping;
 import com.linecorp.bot.spring.boot.annotation.LineMessageHandler;
 import com.linecorp.bot.spring.boot.support.LineMessageHandlerSupport.HandlerMethod;
+import com.linecorp.bot.spring.boot.test.EventTestUtil;
+
+import lombok.AllArgsConstructor;
 
 public class LineMessageHandlerSupportTest {
     @Rule
@@ -47,8 +55,20 @@ public class LineMessageHandlerSupportTest {
     @Mock
     private ConfigurableApplicationContext applicationContext;
 
+    @Mock
+    private ReplyByReturnValueConsumer.Factory replyByReturnValueConsumerFactory;
+
+    @Mock
+    private ReplyByReturnValueConsumer replyByReturnValueConsumer;
+
     @InjectMocks
     private LineMessageHandlerSupport target;
+
+    @Before
+    public void setUp() {
+        when(replyByReturnValueConsumerFactory.createForEvent(any()))
+                .thenReturn(replyByReturnValueConsumer);
+    }
 
     @Test
     public void testRefreshForOneItem() throws Exception {
@@ -93,6 +113,23 @@ public class LineMessageHandlerSupportTest {
                 .isEqualTo("defaultEventHandler");
     }
 
+    @Test
+    public void dispatchAndReplyMessageTest() {
+        final MessageEvent event = EventTestUtil.createTextMessage("text");
+
+        when(applicationContext.getBeansWithAnnotation(LineMessageHandler.class))
+                .thenReturn(singletonMap("bean", new ReplyHandler("Message from Handler method")));
+
+        target.refresh();
+
+        // Do
+        target.dispatch(event);
+
+        // Verify
+        verify(replyByReturnValueConsumerFactory).createForEvent(event);
+        verify(replyByReturnValueConsumer, times(1)).accept(new TextMessage("Message from Handler method"));
+    }
+
     @LineMessageHandler
     public static class MessageHandler {
         @EventMapping
@@ -108,6 +145,17 @@ public class LineMessageHandlerSupportTest {
 
         @EventMapping
         public void textMessageEventHandler(MessageEvent<TextMessageContent> event) {
+        }
+    }
+
+    @LineMessageHandler
+    @AllArgsConstructor
+    public static class ReplyHandler {
+        private final String replyMessage;
+
+        @EventMapping
+        public TextMessage reply(final Event.ReplySupport replySupportEvent) {
+            return new TextMessage(replyMessage);
         }
     }
 }

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/support/ReplyByReturnValueConsumerTest.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/support/ReplyByReturnValueConsumerTest.java
@@ -1,0 +1,156 @@
+package com.linecorp.bot.spring.boot.support;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+import org.junit.rules.ExpectedException;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.linecorp.bot.client.LineMessagingClient;
+import com.linecorp.bot.client.exception.GeneralLineMessagingException;
+import com.linecorp.bot.model.ReplyMessage;
+import com.linecorp.bot.model.event.MessageEvent;
+import com.linecorp.bot.model.message.TextMessage;
+import com.linecorp.bot.model.response.BotApiResponse;
+import com.linecorp.bot.spring.boot.test.EventTestUtil;
+
+public class ReplyByReturnValueConsumerTest {
+    private static final MessageEvent EVENT = EventTestUtil.createTextMessage("text");
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Rule
+    public final SystemOutRule systemOut = new SystemOutRule().enableLog();
+
+    @Mock
+    private LineMessagingClient lineMessagingClient;
+
+    @InjectMocks
+    private ReplyByReturnValueConsumer.Factory targetFactory;
+
+    private ReplyByReturnValueConsumer target;
+
+    @Before
+    public void setUp() {
+        target = targetFactory.createForEvent(EVENT);
+        when(lineMessagingClient.replyMessage(any()))
+                .thenReturn(CompletableFuture.completedFuture(new BotApiResponse("success", null)));
+    }
+
+    // Publich methods test
+
+    @Test
+    public void acceptSingleReplyTest() throws Exception {
+        // Do
+        target.accept(new TextMessage("Reply Text"));
+
+        // Verify
+        verify(lineMessagingClient, only())
+                .replyMessage(new ReplyMessage(EVENT.getReplyToken(),
+                                               singletonList(new TextMessage("Reply Text"))));
+    }
+
+    @Test
+    public void acceptListReplyTest() throws Exception {
+        // Do
+        target.accept(singletonList(new TextMessage("Reply Text")));
+
+        // Verify
+        verify(lineMessagingClient, only())
+                .replyMessage(new ReplyMessage(EVENT.getReplyToken(),
+                                               singletonList(new TextMessage("Reply Text"))));
+    }
+
+    @Test
+    public void acceptCompletableSingleReplyTest() throws Exception {
+        // Do
+        final CompletableFuture<TextMessage> returnValue = new CompletableFuture<>();
+        target.accept(returnValue);
+        returnValue.complete(new TextMessage("Reply Text"));
+
+        // Verify
+        verify(lineMessagingClient, only())
+                .replyMessage(new ReplyMessage(EVENT.getReplyToken(),
+                                               singletonList(new TextMessage("Reply Text"))));
+    }
+
+    @Test
+    public void acceptCompletableListReplyTest() throws Exception {
+        // Do
+        final CompletableFuture<List<TextMessage>> returnValue = new CompletableFuture<>();
+        target.accept(returnValue);
+        returnValue.complete(singletonList(new TextMessage("Reply Text")));
+
+        // Verify
+        verify(lineMessagingClient, only())
+                .replyMessage(new ReplyMessage(EVENT.getReplyToken(),
+                                               singletonList(new TextMessage("Reply Text"))));
+    }
+
+    @Test
+    public void errorInCompletableLoggingTest() {
+        // Do
+        final CompletableFuture<List<TextMessage>> returnValue = new CompletableFuture<>();
+        target.accept(returnValue);
+        returnValue.completeExceptionally(new GeneralLineMessagingException("EXCEPTION HAPPEN!", null, null));
+
+        // Verify
+        assertThat(systemOut.getLogWithNormalizedLineSeparator())
+                .contains("EXCEPTION HAPPEN!");
+    }
+
+    @Test
+    public void errorInLineMessagingClientLoggingTest() {
+        reset(lineMessagingClient);
+        when(lineMessagingClient.replyMessage(any()))
+                .thenReturn(new CompletableFuture<BotApiResponse>() {{
+                    completeExceptionally(new GeneralLineMessagingException("EXCEPTION HAPPEN!", null, null));
+                }});
+
+        // Do
+        final CompletableFuture<List<TextMessage>> returnValue = new CompletableFuture<>();
+        target.accept(returnValue);
+        returnValue.complete(singletonList(new TextMessage("Reply Text")));
+
+        // Verify
+        assertThat(systemOut.getLogWithNormalizedLineSeparator())
+                .contains("failed")
+                .contains("EXCEPTION HAPPEN!");
+    }
+
+    // Internal method test.
+    @Test
+    public void checkListContentsNullTest() throws Exception {
+        expectedException.expect(NullPointerException.class);
+
+        // Do
+        ReplyByReturnValueConsumer.checkListContents(singletonList(null));
+    }
+
+    @Test
+    public void checkListContentsIllegalTypeTest() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+
+        // Do
+        ReplyByReturnValueConsumer.checkListContents(singletonList(new Object()));
+    }
+}

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/test/EventTestUtil.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/test/EventTestUtil.java
@@ -1,0 +1,18 @@
+package com.linecorp.bot.spring.boot.test;
+
+import java.time.Instant;
+
+import com.linecorp.bot.model.event.MessageEvent;
+import com.linecorp.bot.model.event.message.TextMessageContent;
+import com.linecorp.bot.model.event.source.UserSource;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class EventTestUtil {
+    public static MessageEvent<TextMessageContent> createTextMessage(final String text) {
+        return new MessageEvent<>("replyToken", new UserSource("userId"),
+                                  new TextMessageContent("id", text),
+                                  Instant.parse("2016-11-19T00:00:00.000Z"));
+    }
+}

--- a/sample-spring-boot-echo/src/main/java/com/example/bot/spring/echo/EchoApplication.java
+++ b/sample-spring-boot-echo/src/main/java/com/example/bot/spring/echo/EchoApplication.java
@@ -18,42 +18,33 @@ package com.example.bot.spring.echo;
 
 import static java.util.Collections.singletonList;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.List;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-import com.linecorp.bot.client.LineMessagingClient;
-import com.linecorp.bot.model.ReplyMessage;
 import com.linecorp.bot.model.event.Event;
 import com.linecorp.bot.model.event.MessageEvent;
 import com.linecorp.bot.model.event.message.TextMessageContent;
 import com.linecorp.bot.model.message.TextMessage;
-import com.linecorp.bot.model.response.BotApiResponse;
 import com.linecorp.bot.spring.boot.annotation.EventMapping;
 import com.linecorp.bot.spring.boot.annotation.LineMessageHandler;
 
 @SpringBootApplication
 @LineMessageHandler
 public class EchoApplication {
-    @Autowired
-    private LineMessagingClient lineMessagingClient;
-
     public static void main(String[] args) {
         SpringApplication.run(EchoApplication.class, args);
     }
 
     @EventMapping
-    public void handleTextMessageEvent(MessageEvent<TextMessageContent> event) throws Exception {
+    public List<TextMessage> handleTextMessageEvent(MessageEvent<TextMessageContent> event) throws Exception {
         System.out.println("event: " + event);
-        final BotApiResponse apiResponse = lineMessagingClient
-                .replyMessage(new ReplyMessage(event.getReplyToken(),
-                                               singletonList(new TextMessage(event.getMessage().getText()))))
-                .get();
-        System.out.println("Sent messages: " + apiResponse);
+        return singletonList(new TextMessage(event.getMessage().getText()));
     }
 
     @EventMapping
-    public void defaultMessageEvent(Event event) {
+    public void handleDefaultMessageEvent(Event event) {
         System.out.println("event: " + event);
     }
 }


### PR DESCRIPTION
Currently, @EventHandler method return value is always ignored and I proposed treating this values as replyMessage.

I think this feature make creating LINE Bot more easily.

After that. echo application is very simple.


```java
@SpringBootApplication
@LineMessageHandler
public class EchoApplication {
    public static void main(String[] args) {
        SpringApplication.run(EchoApplication.class, args);
    }

    @EventMapping
    public List<TextMessage> handleTextMessageEvent(MessageEvent<TextMessageContent> event) throws Exception {
        System.out.println("event: " + event);
        return singletonList(new TextMessage(event.getMessage().getText()));
    }
}
```

This PR will closes https://github.com/line/line-bot-sdk-java/issues/41

Splitted PRs
----
Please those PRs first.
* https://github.com/line/line-bot-sdk-java/pull/66