### PR TITLE
Introduce ReplySupport interface to determine event support reply or not.

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/BeaconEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/BeaconEvent.java
@@ -32,7 +32,7 @@ import lombok.Value;
  */
 @Value
 @JsonTypeName("beacon")
-public class BeaconEvent implements Event {
+public class BeaconEvent implements Event, Replayable {
     /**
      * Token for replying to this event
      */

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/FollowEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/FollowEvent.java
@@ -31,7 +31,7 @@ import lombok.Value;
  */
 @Value
 @JsonTypeName("follow")
-public class FollowEvent implements Event {
+public class FollowEvent implements Event, Replayable {
     /**
      * Token for replying to this event
      */

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/JoinEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/JoinEvent.java
@@ -31,7 +31,7 @@ import lombok.Value;
  */
 @Value
 @JsonTypeName("join")
-public class JoinEvent implements Event {
+public class JoinEvent implements Event, Replayable {
     /**
      * Token for replying to this event
      */

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/MessageEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/MessageEvent.java
@@ -33,7 +33,7 @@ import lombok.Value;
  */
 @Value
 @JsonTypeName("message")
-public class MessageEvent<T extends MessageContent> implements Event {
+public class MessageEvent<T extends MessageContent> implements Event, Replayable {
     /**
      * Token for replying to this event
      */

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/PostbackEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/PostbackEvent.java
@@ -32,7 +32,7 @@ import lombok.Value;
  */
 @Value
 @JsonTypeName("postback")
-public class PostbackEvent implements Event {
+public class PostbackEvent implements Event, Replayable {
     /**
      * Token for replying to this event
      */

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/Replayable.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/Replayable.java
@@ -1,0 +1,18 @@
+package com.linecorp.bot.model.event;
+
+import com.linecorp.bot.model.ReplyMessage;
+
+/**
+ * Interface for reply support.
+ *
+ * @see Event
+ */
+public interface Replayable {
+    /**
+     * Token for replying to this event.
+     *
+     * @see ReplyMessage
+     * @see <a href="https://devdocs.line.me/#reply-message">//devdocs.line.me/#reply-message</a> &gt; Request Body
+     */
+    String getReplyToken();
+}

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/event/ReplayableTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/event/ReplayableTest.java
@@ -1,0 +1,55 @@
+package com.linecorp.bot.model.event;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.util.ClassUtils;
+
+import com.google.common.base.Preconditions;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ReplayableTest {
+    @Test
+    public void eventWithReplyTokenShouldBeImplementReplySupportTest() {
+        final List<Class<?>> eventClasses = getAllEventClass();
+        Preconditions.checkState(!eventClasses.isEmpty(), "Event classes are empty. Maybe scanning bug.");
+
+        log.info("eventClasses = {}", eventClasses);
+
+        for (Class<?> eventClass : eventClasses) {
+            final boolean hasReplyTokenMethod = ClassUtils.hasMethod(eventClass, "getReplyToken");
+
+            if (hasReplyTokenMethod) {
+                assertThat(Replayable.class)
+                        .isAssignableFrom(eventClass);
+            }
+        }
+    }
+
+    private static List<Class<?>> getAllEventClass() {
+        ClassPathScanningCandidateComponentProvider scanningProvider =
+                new ClassPathScanningCandidateComponentProvider(false);
+        scanningProvider
+                .addIncludeFilter((metadataReader, metadataReaderFactory) -> true);
+
+        return scanningProvider.findCandidateComponents(Event.class.getPackage().getName())
+                               .stream()
+                               .map(BeanDefinition::getBeanClassName)
+                               .map(className -> {
+                                   try {
+                                       return (Class<?>) Class.forName(className);
+                                   } catch (ClassNotFoundException e) {
+                                       throw new RuntimeException(e);
+                                   }
+                               })
+                               .filter(Event.class::isAssignableFrom)
+                               .collect(toList());
+    }
+}


### PR DESCRIPTION
(Splitted from https://github.com/line/line-bot-sdk-java/pull/65)

Currently there are no way to determine event support reply or not.

After this PR. `event instanceof Event.ReplySupport` is solution.

Currently, reply support concept is contained in Event. So let me ReplySupport extends Event.