### PR TITLE
Add file message webhook

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/FileMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/FileMessageContent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.event.message;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import lombok.Value;
+
+@Value
+@JsonTypeName("file")
+public class FileMessageContent implements MessageContent {
+    private final String id;
+    private final String fileName;
+    private final int fileSize;
+
+    @JsonCreator
+    public FileMessageContent(
+            @JsonProperty("id") String id,
+            @JsonProperty("fileName") String fileName,
+            @JsonProperty("fileSize") int fileSize) {
+        this.id = id;
+        this.fileName = fileName;
+        this.fileSize = fileSize;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/MessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/MessageContent.java
@@ -28,7 +28,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
                       @JsonSubTypes.Type(LocationMessageContent.class),
                       @JsonSubTypes.Type(AudioMessageContent.class),
                       @JsonSubTypes.Type(VideoMessageContent.class),
-                      @JsonSubTypes.Type(StickerMessageContent.class)
+                      @JsonSubTypes.Type(StickerMessageContent.class),
+                      @JsonSubTypes.Type(FileMessageContent.class),
               })
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
+import com.linecorp.bot.model.event.message.FileMessageContent;
 import com.linecorp.bot.model.event.message.ImageMessageContent;
 import com.linecorp.bot.model.event.message.LocationMessageContent;
 import com.linecorp.bot.model.event.message.MessageContent;
@@ -134,6 +135,31 @@ public class CallbackRequestTest {
             if (message instanceof LocationMessageContent) {
                 assertThat(((LocationMessageContent) message).getAddress())
                         .isEqualTo("〒150-0002 東京都渋谷区渋谷２丁目２１−１");
+            }
+        });
+    }
+
+    @Test
+    public void testFile() throws IOException {
+        parse("callback/file.json", callbackRequest -> {
+            assertThat(callbackRequest.getEvents()).hasSize(1);
+            Event event = callbackRequest.getEvents().get(0);
+            assertThat(event).isInstanceOf(MessageEvent.class);
+            assertThat(event.getSource())
+                    .isInstanceOf(UserSource.class);
+            assertThat(event.getSource().getUserId())
+                    .isEqualTo("u206d25c2ea6bd87c17655609a1c37cb8");
+
+            MessageEvent messageEvent = (MessageEvent) event;
+            assertThat(messageEvent.getReplyToken())
+                    .isEqualTo("nHuyWiB7yP5Zw52FIkcQobQuGDXCTA");
+            MessageContent message = messageEvent.getMessage();
+            assertThat(message).isInstanceOf(FileMessageContent.class);
+            if (message instanceof FileMessageContent) {
+                assertThat(((FileMessageContent) message).getFileName())
+                        .isEqualTo("sample.pdf");
+                assertThat(((FileMessageContent) message).getFileSize())
+                        .isEqualTo(22016);
             }
         });
     }

--- a/line-bot-model/src/test/resources/callback/file.json
+++ b/line-bot-model/src/test/resources/callback/file.json
@@ -1,0 +1,19 @@
+{
+  "events": [
+    {
+      "replyToken": "nHuyWiB7yP5Zw52FIkcQobQuGDXCTA",
+      "type": "message",
+      "timestamp": 1462629479859,
+      "source": {
+        "type": "user",
+        "userId": "u206d25c2ea6bd87c17655609a1c37cb8"
+      },
+      "message": {
+        "id": "325708",
+        "type": "file",
+        "fileName": "sample.pdf",
+        "fileSize": 22016
+      }
+    }
+  ]
+}


### PR DESCRIPTION
We're going to provide a new webhook for _file_ type message within days.

```
{
  "events":[{
    "type":"message",
    "replyToken":"3ec9a0ccf99941678e9e742ae2ee07aa",
    "source":{"userId":"Uf705e457409a82c316a0b1e5c29f3312","type":"user"},
    "timestamp":1480402184621,
    "message":{
      "id":"721704267",
      "type":"file",
      "fileName":"sample.pdf",
      "fileSize":22016
    }}
  ]
}
```