### PR TITLE
Allow LineBotCallbackRequestParser#handle to accept signature and payload strings

### DIFF
--- a/line-bot-servlet/src/main/java/com/linecorp/bot/servlet/LineBotCallbackRequestParser.java
+++ b/line-bot-servlet/src/main/java/com/linecorp/bot/servlet/LineBotCallbackRequestParser.java
@@ -58,24 +58,8 @@ public class LineBotCallbackRequestParser {
     public CallbackRequest handle(HttpServletRequest req) throws LineBotCallbackException, IOException {
         // validate signature
         String signature = req.getHeader("X-Line-Signature");
-        if (signature == null || signature.length() == 0) {
-            throw new LineBotCallbackException("Missing 'X-Line-Signature' header");
-        }
-
         final byte[] json = ByteStreams.toByteArray(req.getInputStream());
-        if (log.isDebugEnabled()) {
-            log.debug("got: {}", new String(json, StandardCharsets.UTF_8));
-        }
-
-        if (!lineSignatureValidator.validateSignature(json, signature)) {
-            throw new LineBotCallbackException("Invalid API signature");
-        }
-
-        final CallbackRequest callbackRequest = objectMapper.readValue(json, CallbackRequest.class);
-        if (callbackRequest == null || callbackRequest.getEvents() == null) {
-            throw new LineBotCallbackException("Invalid content");
-        }
-        return callbackRequest;
+        return handle(signature, new String(json, StandardCharsets.UTF_8));
     }
     
     /**

--- a/line-bot-servlet/src/main/java/com/linecorp/bot/servlet/LineBotCallbackRequestParser.java
+++ b/line-bot-servlet/src/main/java/com/linecorp/bot/servlet/LineBotCallbackRequestParser.java
@@ -75,16 +75,15 @@ public class LineBotCallbackRequestParser {
         if (signature == null || signature.length() == 0) {
             throw new LineBotCallbackException("Missing 'X-Line-Signature' header");
         }
-        
-        if (log.isDebugEnabled()) {
-            log.debug("got: {}", payload);
-        }
+
+        log.debug("got: {}", payload);
+
         final byte[] json = payload.getBytes(StandardCharsets.UTF_8);
-        
+
         if (!lineSignatureValidator.validateSignature(json, signature)) {
             throw new LineBotCallbackException("Invalid API signature");
         }
-        
+
         final CallbackRequest callbackRequest = objectMapper.readValue(json, CallbackRequest.class);
         if (callbackRequest == null || callbackRequest.getEvents() == null) {
             throw new LineBotCallbackException("Invalid content");


### PR DESCRIPTION
As described in ticket #79 ,

This PR applies an overloading to `LineBotCallbackRequestParser#handle` that will open an opportunity for the developers to use and call it from a normal `RestController`.