### PR TITLE
Add multicast class and API. #84

### DIFF
--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClient.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClient.java
@@ -18,6 +18,7 @@ package com.linecorp.bot.client;
 
 import java.util.concurrent.CompletableFuture;
 
+import com.linecorp.bot.model.Multicast;
 import com.linecorp.bot.model.PushMessage;
 import com.linecorp.bot.model.ReplyMessage;
 import com.linecorp.bot.model.profile.UserProfileResponse;
@@ -46,6 +47,17 @@ public interface LineMessagingClient {
      * @see <a href="https://devdocs.line.me?java#push-message">//devdocs.line.me#push-message</a>
      */
     CompletableFuture<BotApiResponse> pushMessage(PushMessage pushMessage);
+
+    /**
+     * Send messages to multiple users at any time. <strong>IDs of groups or rooms cannot be used.</strong>
+     *
+     * <p>INFO: Only available for plans which support push messages. Messages cannot be sent to groups or rooms.
+     * <p>INFO: Use IDs returned via the webhook event of source users. IDs of groups or rooms cannot be used.
+     * Do not use the LINE ID found on the LINE app.</p>
+     * @see #pushMessage(PushMessage)
+     * @see <a href="https://devdocs.line.me?java#multicast">//devdocs.line.me#multicast</a>
+     */
+    CompletableFuture<BotApiResponse> multicast(Multicast multicast);
 
     /**
      * Download image, video, and audio data sent from users.

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClientImpl.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClientImpl.java
@@ -19,6 +19,7 @@ package com.linecorp.bot.client;
 import java.util.concurrent.CompletableFuture;
 
 import com.linecorp.bot.client.exception.GeneralLineMessagingException;
+import com.linecorp.bot.model.Multicast;
 import com.linecorp.bot.model.PushMessage;
 import com.linecorp.bot.model.ReplyMessage;
 import com.linecorp.bot.model.profile.UserProfileResponse;
@@ -46,6 +47,11 @@ public class LineMessagingClientImpl implements LineMessagingClient {
     @Override
     public CompletableFuture<BotApiResponse> pushMessage(final PushMessage pushMessage) {
         return toFuture(retrofitImpl.pushMessage(pushMessage));
+    }
+
+    @Override
+    public CompletableFuture<BotApiResponse> multicast(final Multicast multicast) {
+        return toFuture(retrofitImpl.multicast(multicast));
     }
 
     @Override

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingService.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingService.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.bot.client;
 
+import com.linecorp.bot.model.Multicast;
 import com.linecorp.bot.model.PushMessage;
 import com.linecorp.bot.model.ReplyMessage;
 import com.linecorp.bot.model.profile.UserProfileResponse;
@@ -54,6 +55,18 @@ public interface LineMessagingService {
      */
     @POST("v2/bot/message/push")
     Call<BotApiResponse> pushMessage(@Body PushMessage pushMessage);
+
+    /**
+     * Send messages to multiple users at any time. <strong>IDs of groups or rooms cannot be used.</strong>
+     *
+     * <p>INFO: Only available for plans which support push messages. Messages cannot be sent to groups or rooms.
+     * <p>INFO: Use IDs returned via the webhook event of source users. IDs of groups or rooms cannot be used.
+     * Do not use the LINE ID found on the LINE app.</p>
+     * @see #pushMessage(PushMessage)
+     * @see <a href="https://devdocs.line.me?java#multicast">//devdocs.line.me#multicast</a>
+     */
+    @POST("v2/bot/message/multicast")
+    Call<BotApiResponse> multicast(@Body Multicast multicast);
 
     /**
      * Download image, video, and audio data sent from users.

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.bot.client;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.only;
@@ -34,6 +35,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.OngoingStubbing;
 
+import com.linecorp.bot.model.Multicast;
 import com.linecorp.bot.model.PushMessage;
 import com.linecorp.bot.model.ReplyMessage;
 import com.linecorp.bot.model.message.TextMessage;
@@ -90,6 +92,21 @@ public class LineMessagingClientImplTest {
 
         // Verify
         verify(retrofitMock, only()).pushMessage(pushMessage);
+        assertThat(botApiResponse).isEqualTo(BOT_API_SUCCESS_RESPONSE);
+    }
+
+    @Test
+    public void multicastTest() throws Exception {
+        whenCall(retrofitMock.multicast(any()),
+                 BOT_API_SUCCESS_RESPONSE);
+        final Multicast multicast = new Multicast(singleton("TO"), new TextMessage("text"));
+
+        // Do
+        final BotApiResponse botApiResponse =
+                target.multicast(multicast).get();
+
+        // Verify
+        verify(retrofitMock, only()).multicast(multicast);
         assertThat(botApiResponse).isEqualTo(BOT_API_SUCCESS_RESPONSE);
     }
 

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/Multicast.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/Multicast.java
@@ -1,0 +1,36 @@
+package com.linecorp.bot.model;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import com.linecorp.bot.model.message.Message;
+
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+/**
+ * Send messages to multiple users, groups, and rooms at any time.
+ */
+@Value
+@AllArgsConstructor
+public class Multicast {
+    /**
+     * IDs of the receivers.<br />
+     * Max: 150
+     *
+     * <p>INFO: Use IDs returned via the webhook event of source users. IDs of groups or rooms cannot be used.</p>
+     */
+    private final Set<String> to;
+
+    /**
+     * List of Message objects.<br />
+     * Max: 5
+     */
+    private final List<Message> messages;
+
+    public Multicast(final Set<String> to, final Message message) {
+        this.to = to;
+        this.messages = Collections.singletonList(message);
+    }
+}


### PR DESCRIPTION
See https://devdocs.line.me?java#multicast for detail.

This patch cloases [Issue 84](https://github.com/line/line-bot-sdk-java/issues/84)

Logs
----
```
2017-01-16 14:59:08.187 --- com.linecorp.bot.client.wire : --> POST https://api.line.me/v2/bot/message/multicast http/1.1
2017-01-16 14:59:08.188 --- com.linecorp.bot.client.wire : Content-Type: application/json; charset=UTF-8
2017-01-16 14:59:08.188 --- com.linecorp.bot.client.wire : Content-Length: 92
2017-01-16 14:59:08.188 --- com.linecorp.bot.client.wire : Authorization: Bearer SECRET!
2017-01-16 14:59:08.188 --- com.linecorp.bot.client.wire : User-Agent: line-botsdk-java/null
2017-01-16 14:59:08.192 --- com.linecorp.bot.client.wire :
2017-01-16 14:59:08.192 --- com.linecorp.bot.client.wire : {"to":["Uxxxxxxxxxxxxxxxxxxx"],"messages":[{"type":"text","text":"Multicast"}]}
2017-01-16 14:59:08.192 --- com.linecorp.bot.client.wire : --> END POST (92-byte body)
2017-01-16 14:59:08.527 --- com.linecorp.bot.client.wire : <-- 200  https://api.line.me/v2/bot/message/multicast (334ms)
2017-01-16 14:59:08.527 --- com.linecorp.bot.client.wire : Server: nginx
2017-01-16 14:59:08.527 --- com.linecorp.bot.client.wire : Date: Mon, 16 Jan 2017 05:59:08 GMT
2017-01-16 14:59:08.527 --- com.linecorp.bot.client.wire : Content-Type: application/json;charset=UTF-8
2017-01-16 14:59:08.527 --- com.linecorp.bot.client.wire : Transfer-Encoding: chunked
2017-01-16 14:59:08.527 --- com.linecorp.bot.client.wire : Connection: keep-alive
2017-01-16 14:59:08.527 --- com.linecorp.bot.client.wire : X-Line-Request-Id: 82e6e42a-ec45-492f-8ba1-042bc6d57788
2017-01-16 14:59:08.527 --- com.linecorp.bot.client.wire : X-Content-Type-Options: nosniff
2017-01-16 14:59:08.527 --- com.linecorp.bot.client.wire : X-XSS-Protection: 1; mode=block
2017-01-16 14:59:08.527 --- com.linecorp.bot.client.wire : Cache-Control: no-cache, no-store, max-age=0, must-revalidate
2017-01-16 14:59:08.527 --- com.linecorp.bot.client.wire : Pragma: no-cache
2017-01-16 14:59:08.528 --- com.linecorp.bot.client.wire : Expires: 0
2017-01-16 14:59:08.528 --- com.linecorp.bot.client.wire : X-Frame-Options: DENY
2017-01-16 14:59:08.528 --- com.linecorp.bot.client.wire :
2017-01-16 14:59:08.528 --- com.linecorp.bot.client.wire : {}
```