### PR TITLE
Add @Validated annotaation into ConfigurationProperties class

### DIFF
--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotProperties.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotProperties.java
@@ -22,6 +22,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 import com.linecorp.bot.client.LineMessagingServiceBuilder;
 import com.linecorp.bot.spring.boot.annotation.EventMapping;
@@ -30,6 +31,7 @@ import com.linecorp.bot.spring.boot.annotation.LineMessageHandler;
 import lombok.Data;
 
 @Data
+@Validated
 @ConfigurationProperties(prefix = "line.bot")
 public class LineBotProperties {
     /**


### PR DESCRIPTION
When I use SpringBoot 1.5.x, following warns are logged out.

```
WARN  ConfigurationPropertiesBindingPostProcessor
The @ConfigurationProperties bean class com.linecorp.bot.spring.boot.LineBotProperties contains validation constraints but had not been annotated with @Validated.
```

ref

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-1.5-Release-Notes#configurationproperties-validation

> @ConfigurationProperties validation
> If you have @ConfigurationProperties classes that use JSR-303 constraint annotations, you should now additionally annotate them with @Validated. Existing validation will currently continue to work, however, a warning will be logged. In the future, classes without @Validated will not be validated at all.