### PR TITLE
Make channel token injectable for business partners.

### DIFF
--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/ChannelTokenSupplier.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/ChannelTokenSupplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import java.util.function.Supplier;
+
+/**
+ * Special {@link Supplier} for Channel Access Token.
+ *
+ * You can implement it to return same channel tokens.
+ * Or refresh tokens internally.
+ */
+@FunctionalInterface
+public interface ChannelTokenSupplier extends Supplier<String> {
+}

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/FixedChannelTokenSupplier.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/FixedChannelTokenSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.ToString;
+
+/**
+ * Implementation of {@link ChannelTokenSupplier} which always return fixed channel token.
+ */
+@AllArgsConstructor(staticName = "of")
+@ToString
+public final class FixedChannelTokenSupplier implements ChannelTokenSupplier {
+    @NonNull
+    private final String channelToken;
+
+    @Override
+    public String get() {
+        return channelToken;
+    }
+}

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/HeaderInterceptor.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/HeaderInterceptor.java
@@ -18,21 +18,20 @@ package com.linecorp.bot.client;
 
 import java.io.IOException;
 
+import lombok.AllArgsConstructor;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 
+@AllArgsConstructor(staticName = "forChannelTokenSupplier")
 class HeaderInterceptor implements Interceptor {
     private static final String USER_AGENT =
             "line-botsdk-java/" + HeaderInterceptor.class.getPackage().getImplementationVersion();
-    private final String channelToken;
-
-    HeaderInterceptor(String channelToken) {
-        this.channelToken = channelToken;
-    }
+    private final ChannelTokenSupplier channelTokenSupplier;
 
     @Override
     public Response intercept(Chain chain) throws IOException {
+        final String channelToken = channelTokenSupplier.get();
         Request request = chain.request().newBuilder()
                                .addHeader("Authorization", "Bearer " + channelToken)
                                .addHeader("User-Agent", USER_AGENT)

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingServiceBuilder.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingServiceBuilder.java
@@ -51,10 +51,17 @@ public final class LineMessagingServiceBuilder {
     private Retrofit.Builder retrofitBuilder;
 
     /**
-     * Create a new {@link LineMessagingServiceBuilder} with specified channelToken.
+     * Create a new {@link LineMessagingServiceBuilder} with specified given fixed channelToken.
      */
-    public static LineMessagingServiceBuilder create(@NonNull String channelToken) {
-        return new LineMessagingServiceBuilder(defaultInterceptors(channelToken));
+    public static LineMessagingServiceBuilder create(@NonNull String fixedChannelToken) {
+        return create(FixedChannelTokenSupplier.of(fixedChannelToken));
+    }
+
+    /**
+     * Create a new {@link LineMessagingServiceBuilder} with specified {@link ChannelTokenSupplier}.
+     */
+    public static LineMessagingServiceBuilder create(@NonNull ChannelTokenSupplier channelTokenSupplier) {
+        return new LineMessagingServiceBuilder(defaultInterceptors(channelTokenSupplier));
     }
 
     private LineMessagingServiceBuilder(List<Interceptor> interceptors) {
@@ -151,14 +158,14 @@ public final class LineMessagingServiceBuilder {
         return retrofit.create(LineMessagingService.class);
     }
 
-    private static List<Interceptor> defaultInterceptors(String channelToken) {
+    private static List<Interceptor> defaultInterceptors(final ChannelTokenSupplier channelTokenSupplier) {
         final Logger slf4jLogger = LoggerFactory.getLogger("com.linecorp.bot.client.wire");
         final HttpLoggingInterceptor httpLoggingInterceptor =
                 new HttpLoggingInterceptor(message -> slf4jLogger.info("{}", message));
         httpLoggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
 
         return Arrays.asList(
-                new HeaderInterceptor(channelToken),
+                HeaderInterceptor.forChannelTokenSupplier(channelTokenSupplier),
                 httpLoggingInterceptor
         );
     }

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/AbstractWiremockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/AbstractWiremockTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import org.junit.After;
+import org.junit.Before;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import com.linecorp.bot.model.error.ErrorResponse;
+
+import lombok.SneakyThrows;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+public abstract class AbstractWiremockTest {
+    public static final int ASYNC_TEST_TIMEOUT = 1_000;
+    private static final ObjectWriter ERROR_RESPONSE_READER = new ObjectMapper().writerFor(ErrorResponse.class);
+
+    static {
+        SLF4JBridgeHandler.install();
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+    }
+
+    protected MockWebServer mockWebServer;
+    protected LineMessagingClient lineMessagingClient;
+
+    @Before
+    public void setUpWireMock() {
+        mockWebServer = new MockWebServer();
+        lineMessagingClient = createLineMessagingClient(mockWebServer);
+    }
+
+    @After
+    public void shutDownWireMock() throws Exception {
+        mockWebServer.shutdown();
+    }
+
+    @SneakyThrows
+    public void mocking(final int responseCode, final ErrorResponse errorResponse) {
+        mockWebServer
+                .enqueue(new MockResponse()
+                                 .setResponseCode(responseCode)
+                                 .setBody(ERROR_RESPONSE_READER.writeValueAsString(errorResponse)));
+    }
+
+    protected LineMessagingClientImpl createLineMessagingClient(final MockWebServer mockWebServer) {
+        LineMessagingService lineMessagingService =
+                LineMessagingServiceBuilder.create("token")
+                                           .apiEndPoint("http://localhost:" + mockWebServer.getPort())
+                                           .build();
+        return new LineMessagingClientImpl(lineMessagingService);
+    }
+}

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/FixedChannelTokenSupplierTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/FixedChannelTokenSupplierTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.junit.Test;
+
+public class FixedChannelTokenSupplierTest {
+    @Test(expected = NullPointerException.class)
+    public void constructedInstanceAlwaysNonNullTest() {
+        // Do
+        FixedChannelTokenSupplier.of(null);
+
+        // Verify
+        fail("NullPointerException is not occurred.");
+    }
+
+    @Test
+    public void getTest() {
+        ChannelTokenSupplier target = FixedChannelTokenSupplier.of("FIXED_TOKEN");
+
+        // DO
+        String result = target.get();
+
+        // Verify
+        assertThat(result).isEqualTo("FIXED_TOKEN");
+    }
+}

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/HeaderInterceptorWireMockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/HeaderInterceptorWireMockTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+public class HeaderInterceptorWireMockTest extends AbstractWiremockTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    ChannelTokenSupplier channelTokenSupplier;
+
+    @Test(timeout = ASYNC_TEST_TIMEOUT)
+    public void forChannelTokenSupplier() throws Exception {
+        // Do
+        when(channelTokenSupplier.get()).thenReturn("1st");
+        lineMessagingClient.getMessageContent("TEST");
+
+        // Verify
+        final RecordedRequest request1st = mockWebServer.takeRequest();
+        assertThat(request1st.getHeaders().toMultimap())
+                .containsEntry("Authorization", singletonList("Bearer 1st"));
+
+        // Do again with another channel token.
+        when(channelTokenSupplier.get()).thenReturn("2nd");
+        lineMessagingClient.getMessageContent("TEST");
+
+        // Verify
+        final RecordedRequest request2nd = mockWebServer.takeRequest();
+        assertThat(request2nd.getHeaders().toMultimap())
+                .containsEntry("Authorization", singletonList("Bearer 2nd"));
+    }
+
+    @Override
+    protected LineMessagingClientImpl createLineMessagingClient(final MockWebServer mockWebServer) {
+        LineMessagingService lineMessagingService =
+                LineMessagingServiceBuilder.create(channelTokenSupplier)
+                                           .apiEndPoint("http://localhost:" + mockWebServer.getPort())
+                                           .build();
+        return new LineMessagingClientImpl(lineMessagingService);
+    }
+}

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplWiremockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplWiremockTest.java
@@ -44,35 +44,9 @@ import lombok.SneakyThrows;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 
-public class LineMessagingClientImplWiremockTest {
-    static {
-        SLF4JBridgeHandler.install();
-        SLF4JBridgeHandler.removeHandlersForRootLogger();
-    }
-
-    private static final ObjectWriter ERROR_RESPONSE_READER = new ObjectMapper().writerFor(ErrorResponse.class);
-    private static final int ASYNC_TEST_TIMEOUT = 1_000;
-
+public class LineMessagingClientImplWiremockTest extends AbstractWiremockTest {
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
-
-    private MockWebServer mockWebServer;
-    private LineMessagingClient lineMessagingClient;
-
-    @Before
-    public void setUp() {
-        mockWebServer = new MockWebServer();
-        LineMessagingService lineMessagingService =
-                LineMessagingServiceBuilder.create("token")
-                                           .apiEndPoint("http://localhost:" + mockWebServer.getPort())
-                                           .build();
-        lineMessagingClient = new LineMessagingClientImpl(lineMessagingService);
-    }
-
-    @After
-    public void shutDown() throws Exception {
-        mockWebServer.shutdown();
-    }
 
     @Test(timeout = ASYNC_TEST_TIMEOUT)
     public void status400BadRequestTest() throws Exception {
@@ -157,14 +131,6 @@ public class LineMessagingClientImplWiremockTest {
 
         // Do
         lineMessagingClient.getMessageContent("TOKEN").get();
-    }
-
-    @SneakyThrows
-    private void mocking(final int responseCode, final ErrorResponse errorResponse) {
-        mockWebServer
-                .enqueue(new MockResponse()
-                                 .setResponseCode(responseCode)
-                                 .setBody(ERROR_RESPONSE_READER.writeValueAsString(errorResponse)));
     }
 
     private CustomTypeSafeMatcher<LineMessagingException> errorResponseIs(final ErrorResponse errorResponse) {

--- a/line-bot-spring-boot/README.md
+++ b/line-bot-spring-boot/README.md
@@ -77,6 +77,7 @@ The Messaging API SDK is automatically configured by the system properties. The 
 | ----- | ------ |
 | line.bot.channelToken | Channel access token for the server |
 | line.bot.channelSecret | Channel secret for the server |
+| line.bot.channelTokenSupplyMode | The way to fix channel access token. (default: `FIXED`)<br>LINE Partners should change this value to `SUPPLIER` and create custom `ChannelTokenSupplier` bean. |
 | line.bot.connectTimeout | Connection timeout in milliseconds |
 | line.bot.readTimeout | Read timeout in milliseconds |
 | line.bot.writeTimeout | Write timeout in milliseconds |

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/BotPropertiesValidator.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/BotPropertiesValidator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.spring.boot;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+
+import com.linecorp.bot.spring.boot.BotPropertiesValidator.ValidBotProperties;
+
+public class BotPropertiesValidator implements ConstraintValidator<ValidBotProperties, LineBotProperties> {
+    @Target({ ElementType.TYPE })
+    @Retention(RUNTIME)
+    @Documented
+    @Constraint(validatedBy = { BotPropertiesValidator.class })
+    public @interface ValidBotProperties {
+        Class<?>[] groups() default {};
+
+        String message() default "";
+
+        Class<? extends Payload>[] payload() default {};
+
+    }
+
+    @Override
+    public void initialize(ValidBotProperties constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(LineBotProperties value, ConstraintValidatorContext context) {
+        switch (value.getChannelTokenSupplyMode()) {
+            case FIXED:
+                if (value.getChannelToken() != null) {
+                    return true;
+                } else {
+                    context.buildConstraintViolationWithTemplate("channelToken is null")
+                           .addPropertyNode("channelToken")
+                           .addConstraintViolation();
+                    return false;
+                }
+            case SUPPLIER:
+                if (value.getChannelToken() == null) {
+                    return true;
+                } else {
+                    context.buildConstraintViolationWithTemplate(
+                            "channelToken should be null if channelTokenSupplyMode = SUPPLIER")
+                           .addPropertyNode("channelToken")
+                           .addConstraintViolation();
+                    return false;
+                }
+        }
+        throw new IllegalStateException("Not implemented channelTokenSupplyMode.");
+    }
+}

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotAutoConfiguration.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotAutoConfiguration.java
@@ -20,12 +20,15 @@ import java.nio.charset.StandardCharsets;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import com.linecorp.bot.client.ChannelTokenSupplier;
+import com.linecorp.bot.client.FixedChannelTokenSupplier;
 import com.linecorp.bot.client.LineMessagingClient;
 import com.linecorp.bot.client.LineMessagingClientImpl;
 import com.linecorp.bot.client.LineMessagingService;
@@ -45,14 +48,22 @@ public class LineBotAutoConfiguration {
     private LineBotProperties lineBotProperties;
 
     @Bean
-    public LineMessagingService lineMessagingService() {
+    public LineMessagingService lineMessagingService(
+            final ChannelTokenSupplier channelTokenSupplier) {
         return LineMessagingServiceBuilder
-                .create(lineBotProperties.getChannelToken())
+                .create(channelTokenSupplier)
                 .apiEndPoint(lineBotProperties.getApiEndPoint())
                 .connectTimeout(lineBotProperties.getConnectTimeout())
                 .readTimeout(lineBotProperties.getReadTimeout())
                 .writeTimeout(lineBotProperties.getWriteTimeout())
                 .build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(ChannelTokenSupplier.class)
+    public ChannelTokenSupplier channelTokenSupplier() {
+        final String channelToken = lineBotProperties.getChannelToken();
+        return FixedChannelTokenSupplier.of(channelToken);
     }
 
     @Bean

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotProperties.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotProperties.java
@@ -25,6 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 import com.linecorp.bot.client.LineMessagingServiceBuilder;
+import com.linecorp.bot.spring.boot.BotPropertiesValidator.ValidBotProperties;
 import com.linecorp.bot.spring.boot.annotation.EventMapping;
 import com.linecorp.bot.spring.boot.annotation.LineMessageHandler;
 
@@ -32,13 +33,22 @@ import lombok.Data;
 
 @Data
 @Validated
+@ValidBotProperties
 @ConfigurationProperties(prefix = "line.bot")
 public class LineBotProperties {
+    /**
+     * Channel token supply mode.
+     *
+     * @see ChannelTokenSupplyMode
+     */
+    @Valid
+    @NotNull
+    private ChannelTokenSupplyMode channelTokenSupplyMode = ChannelTokenSupplyMode.FIXED;
+
     /**
      * Channel acccess token.
      */
     @Valid
-    @NotNull
     private String channelToken;
 
     /**
@@ -94,5 +104,20 @@ public class LineBotProperties {
          */
         @NotNull
         URI path = URI.create("/callback");
+    }
+
+    enum ChannelTokenSupplyMode {
+        /**
+         * Use fixed channel token for public API user.
+         */
+        FIXED,
+
+        /**
+         * Supply channel token via channel token supplier for specific business partners.
+         *
+         * @see <a href="https://devdocs.line.me/#issue-channel-access-token"
+         * >//devdocs.line.me/#issue-channel-access-token</a>
+         */
+        SUPPLIER,
     }
 }

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/BotPropertiesValidatorTest.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/BotPropertiesValidatorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.spring.boot;
+
+import static com.linecorp.bot.spring.boot.LineBotProperties.ChannelTokenSupplyMode.SUPPLIER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.internal.engine.path.PathImpl.createPathFromString;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class BotPropertiesValidatorTest {
+    private static Validator VALIDATOR;
+
+    @BeforeClass
+    public static void setUpClass() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        VALIDATOR = factory.getValidator();
+    }
+
+    @Test
+    public void okForFixedTest() {
+        // Do
+        Set<ConstraintViolation<LineBotProperties>> constraintViolations =
+                VALIDATOR.validate(new LineBotProperties() {{
+                    setChannelSecret("SECRET");
+                    setChannelToken("TOKEN");
+                }});
+
+        //Verify
+        assertThat(constraintViolations).isEmpty();
+    }
+
+    @Test
+    public void ngForFixedTest() {
+        // Do
+        Set<ConstraintViolation<LineBotProperties>> constraintViolations =
+                VALIDATOR.validate(new LineBotProperties() {{
+                    setChannelSecret("SECRET");
+                }});
+
+        //Verify
+        assertThat(constraintViolations)
+                .isNotEmpty()
+                .filteredOn("propertyPath", createPathFromString("channelToken"))
+                .hasOnlyOneElementSatisfying(violation -> {
+                    assertThat(violation.getMessage()).isEqualTo("channelToken is null");
+                });
+    }
+
+    @Test
+    public void okForSupplierTest() {
+        // Do
+        Set<ConstraintViolation<LineBotProperties>> constraintViolations =
+                VALIDATOR.validate(new LineBotProperties() {{
+                    setChannelTokenSupplyMode(SUPPLIER);
+                    setChannelSecret("SECRET");
+                }});
+
+        //Verify
+        assertThat(constraintViolations).isEmpty();
+    }
+
+    @Test
+    public void ngForSupplierTest() {
+        // Do
+        Set<ConstraintViolation<LineBotProperties>> constraintViolations =
+                VALIDATOR.validate(new LineBotProperties() {{
+                    setChannelTokenSupplyMode(SUPPLIER);
+                    setChannelSecret("SECRET");
+                    setChannelToken("TOKEN");
+                }});
+
+        //Verify
+        assertThat(constraintViolations)
+                .isNotEmpty()
+                .filteredOn("propertyPath", createPathFromString("channelToken"))
+                .hasOnlyOneElementSatisfying(violation -> {
+                    assertThat(violation.getMessage())
+                            .isEqualTo("channelToken should be null if channelTokenSupplyMode = SUPPLIER");
+                });
+    }
+}


### PR DESCRIPTION
In some cases described in https://github.com/line/line-bot-sdk-java/issues/103,
extension point to inject current effective channel access token is useful.

```java
@Service
public static class MyChannelTokenSupplier implements ChannelTokenSupplier {
    private volatile String channelToken;

    @Override
    public String get() {
        return channelToken;
    }

    @PostConstruct
    public void loadLastIssuedChannelToken() {
        // Fill your custom code to load last issued channel token.
        refreshChannelTokenViaAPIIfExpiresSoon();
    }

    @Scheduled(fixedRate = 60)
    public void refreshChannelTokenViaAPIIfExpiresSoon() {
        // Fill your custom code to check channel token expires date and re-issue if needed.
    }
}
```