### PR TITLE
Refactor: Remove @JsonTypeInfo#visible=true when not needed.

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/action/Action.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/action/Action.java
@@ -26,8 +26,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
         include = As.PROPERTY,
-        property = "type",
-        visible = true
+        property = "type"
 )
 @JsonSubTypes({
         @JsonSubTypes.Type(PostbackAction.class),

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/imagemap/ImagemapAction.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/imagemap/ImagemapAction.java
@@ -28,8 +28,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
         include = As.PROPERTY,
-        property = "type",
-        visible = true
+        property = "type"
 )
 @JsonSubTypes({
         @JsonSubTypes.Type(MessageImagemapAction.class),

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/Template.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/Template.java
@@ -31,8 +31,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
         include = As.PROPERTY,
-        property = "type",
-        visible = true
+        property = "type"
 )
 public interface Template {
 }


### PR DESCRIPTION
According to document, it is configure deserialization behavior only.

Setting this value to default (false) is suitable for super class/interface which subclass are all known.

> com.fasterxml.jackson.annotation.JsonTypeInfo
> public boolean visible()
>
> Property that defines whether type identifier value will be passed as part of JSON stream to deserializer (true), or handled and removed by TypeDeserializer (false). Property has no effect on serialization.
>
> Default value is false, meaning that Jackson handles and removes the type identifier from JSON content that is passed to JsonDeserializer.