### PR TITLE
Modified to use multiple channels in one BOT.

### DIFF
--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/BotInfo.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/BotInfo.java
@@ -1,0 +1,53 @@
+package com.linecorp.bot.spring.boot;
+
+import com.linecorp.bot.client.LineMessagingServiceBuilder;
+import lombok.Data;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Created by pptwe on 2017-04-15.
+ */
+@Data
+public class BotInfo
+{
+    /**
+     * Channel acccess token.
+     */
+    @Valid
+    @NotNull
+    private String channelToken;
+
+    /**
+     * Channel secret
+     */
+    @Valid
+    @NotNull
+    private String channelSecret;
+
+    @Valid
+    @NotNull
+    private String apiEndPoint = LineMessagingServiceBuilder.DEFAULT_API_END_POINT;
+
+    /**
+     * Connection timeout in milliseconds
+     */
+    @Valid
+    @NotNull
+    private long connectTimeout = LineMessagingServiceBuilder.DEFAULT_CONNECT_TIMEOUT;
+
+    /**
+     * Read timeout in milliseconds
+     */
+    @Valid
+    @NotNull
+    private long readTimeout = LineMessagingServiceBuilder.DEFAULT_READ_TIMEOUT;
+
+    /**
+     * Write timeout in milliseconds
+     */
+    @Valid
+    @NotNull
+    private long writeTimeout = LineMessagingServiceBuilder.DEFAULT_WRITE_TIMEOUT;
+}

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotProperties.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotProperties.java
@@ -16,62 +16,32 @@
 
 package com.linecorp.bot.spring.boot;
 
-import java.net.URI;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
+import com.linecorp.bot.spring.boot.annotation.EventMapping;
+import com.linecorp.bot.spring.boot.annotation.LineMessageHandler;
+import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
-import com.linecorp.bot.client.LineMessagingServiceBuilder;
-import com.linecorp.bot.spring.boot.annotation.EventMapping;
-import com.linecorp.bot.spring.boot.annotation.LineMessageHandler;
-
-import lombok.Data;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @Validated
 @ConfigurationProperties(prefix = "line.bot")
-public class LineBotProperties {
-    /**
-     * Channel acccess token.
-     */
-    @Valid
-    @NotNull
-    private String channelToken;
+public class LineBotProperties extends BotInfo
+{
+    private List<BotInfo> list = new ArrayList<>();
 
-    /**
-     * Channel secret
-     */
-    @Valid
-    @NotNull
-    private String channelSecret;
-
-    @Valid
-    @NotNull
-    private String apiEndPoint = LineMessagingServiceBuilder.DEFAULT_API_END_POINT;
-
-    /**
-     * Connection timeout in milliseconds
-     */
-    @Valid
-    @NotNull
-    private long connectTimeout = LineMessagingServiceBuilder.DEFAULT_CONNECT_TIMEOUT;
-
-    /**
-     * Read timeout in milliseconds
-     */
-    @Valid
-    @NotNull
-    private long readTimeout = LineMessagingServiceBuilder.DEFAULT_READ_TIMEOUT;
-
-    /**
-     * Write timeout in milliseconds
-     */
-    @Valid
-    @NotNull
-    private long writeTimeout = LineMessagingServiceBuilder.DEFAULT_WRITE_TIMEOUT;
+    public List<BotInfo> getAllBotList()
+    {
+        List<BotInfo> cloneList = new ArrayList<>();
+        cloneList.add(this);
+        cloneList.addAll(list);
+        return cloneList;
+    }
 
     /**
      * Configuration for {@link LineMessageHandler} and {@link EventMapping}.

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/annotation/EventMapping.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/annotation/EventMapping.java
@@ -43,4 +43,6 @@ public @interface EventMapping {
      * Priority of this mapping. Bigger mapping is preferentially searched and matched.
      */
     int priority() default DEFAULT_PRIORITY_VALUE;
+
+    String secretKey() default "";
 }

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/custom/LineMessagingClientFactory.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/custom/LineMessagingClientFactory.java
@@ -1,0 +1,26 @@
+package com.linecorp.bot.spring.boot.custom;
+
+import com.linecorp.bot.client.LineMessagingClient;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Created by kimjh on 2017-04-14.
+ */
+public class LineMessagingClientFactory
+{
+    private final ConcurrentMap<String, LineMessagingClient> lineMessagingClientMap;
+
+    public LineMessagingClientFactory(Map<String, LineMessagingClient> map)
+    {
+        lineMessagingClientMap = new ConcurrentHashMap<>();
+        lineMessagingClientMap.putAll(map);
+    }
+
+    public LineMessagingClient get(String key)
+    {
+        return lineMessagingClientMap.get(key);
+    }
+}

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/interceptor/LineBotServerInterceptor.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/interceptor/LineBotServerInterceptor.java
@@ -17,6 +17,7 @@
 package com.linecorp.bot.spring.boot.interceptor;
 
 import java.io.PrintWriter;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -51,7 +52,7 @@ public class LineBotServerInterceptor implements HandlerInterceptor {
         for (MethodParameter methodParameter : methodParameters) {
             if (methodParameter.getParameterAnnotation(LineBotMessages.class) != null) {
                 try {
-                    CallbackRequest callbackRequest = lineBotCallbackRequestParser.handle(request);
+                    Map.Entry<String, CallbackRequest> callbackRequest = lineBotCallbackRequestParser.handle(request);
                     LineBotServerArgumentProcessor.setValue(request, callbackRequest);
                     return true;
                 } catch (LineBotCallbackException e) {

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineBotServerArgumentProcessor.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineBotServerArgumentProcessor.java
@@ -29,9 +29,12 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 import com.linecorp.bot.model.event.CallbackRequest;
 import com.linecorp.bot.spring.boot.annotation.LineBotMessages;
 
+import java.util.Map;
+
 @Component
 public class LineBotServerArgumentProcessor implements HandlerMethodArgumentResolver {
     private static final String PROPERTY_NAME = "com.linecorp.bot.spring.callbackRequest";
+    public static final String SECRET_KEY = "secretkey";
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -45,7 +48,8 @@ public class LineBotServerArgumentProcessor implements HandlerMethodArgumentReso
         return webRequest.getAttribute(PROPERTY_NAME, RequestAttributes.SCOPE_REQUEST);
     }
 
-    public static void setValue(HttpServletRequest request, CallbackRequest callbackRequest) {
-        request.setAttribute(PROPERTY_NAME, callbackRequest.getEvents());
+    public static void setValue(HttpServletRequest request, Map.Entry<String, CallbackRequest> callbackRequest) {
+        request.setAttribute(PROPERTY_NAME, callbackRequest.getValue().getEvents());
+        request.setAttribute(SECRET_KEY, callbackRequest.getKey());
     }
 }

--- a/sample-spring-boot-echo/src/main/resources/application-template.yml
+++ b/sample-spring-boot-echo/src/main/resources/application-template.yml
@@ -1,28 +1,12 @@
-#
-# Copyright 2016 LINE Corporation
-#
-# LINE Corporation licenses this file to you under the Apache License,
-# version 2.0 (the "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at:
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
-
-This is tempalte file for configuration.
-Please copy as `application.yml` and change your value.
+server.use-forward-headers: true
+server:
+  port: 7777
 
 line.bot:
-  channel-token: 'Put Your Channel Token Here.'
-  channel-secret: 'Put Your Channel Secret Here.'
   handler.path: /callback
+  channel-token: ${your-channel-token-1}
+  channel-secret: ${your-channel-secret-1}
+  list :
+    - channel-token: ${your-channel-token-2}
+      channel-secret: ${your-channel-secret-2}
 
-# To remove Client wire logs. Please comment out following lines.
-# See: https://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html
-#
-#logging.level:
-#   com.linecorp.bot.client.wire: INFO


### PR DESCRIPTION
SpringBoot-based annotations Using the `@ EventMapping` and` LineMessagingClientFactory` classes, multiple API accounts can be controlled from a single bot.

configuration
----

- application.yml
```yaml
line.bot:
  handler.path: /callback
  channel-token: channel-token-1
  channel-secret: channel-secret-1
  list :
    - channel-token: channel-token-2
      channel-secret: channel-secret-2
    - channel-token: channel-token-3
      channel-secret: channel-secret-3
      ...
```

Java
----
In the example below, only events of `channel-secret-1` are processed.

```java
@EventMapping
public void handler(Event event){
  ...
}
```

However, if you use multiple accounts, you can receive and process the channel-secret key as shown below.

```java
@EventMapping
public void handler(Event event, String secretKey){
  ...
}
```

If you only want to process events for a specific account, you can use:

```java
@EventMapping(secretKey = "${channel-secret-1}")
public void handler1(Event event, String secretKey){
  ...
}

@EventMapping(secretKey = "${channel-secret-2}")
public void handler2(Event event){
  ...
}
```

For the `channel-secret-1` account under `line.bot`, you can use the existing `LineMessagingClient` bean as shown below.

```java
@Autowired
private LineMessagingClient lineMessagingClient;

@EventMapping
public void handler(Event event){
  lineMessagingClient.pushMessage( ... );
}
```

However, if you use the `LineMessagingClientFactory` bean, you can use all channels.

```java
@Autowired
private LineMessagingClientFactory lineMessagingClientFactory;

@EventMapping
public void handler(Event event, String secretKey){
  lineMessagingClientFactory.get(secretKey).pushMessage( ... );
}
```    
