### PR TITLE
Add Message serializetion/deserialization.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ subprojects {
     }
 
     compileJava {
-        options.compilerArgs << '-Xlint:all' << '-Xlint:-processing'
+        options.compilerArgs << '-Xlint:all' << '-Xlint:-processing' << '-parameters'
 
         if (!isDevBuild) {
             options.compilerArgs << '-Werror'

--- a/line-bot-model/build.gradle
+++ b/line-bot-model/build.gradle
@@ -19,5 +19,6 @@ dependencies {
     compile 'com.fasterxml.jackson.core:jackson-databind'
     compile 'com.fasterxml.jackson.core:jackson-annotations'
 
+    testCompile 'com.fasterxml.jackson.module:jackson-module-parameter-names'
     testCompile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/Message.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/Message.java
@@ -20,11 +20,19 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 
+/**
+ * Interface of Message object.
+ *
+ * <h2>JSON Deserialization</h2>
+ *
+ * <p>If you want serialize/deserialize of this object, please use Jackson's ObjectMapper with
+ *
+ * <pre>.registerModule(new <a href="https://github.com/FasterXML/jackson-modules-java8/tree/master/parameter-names">ParameterNamesModule</a>());</pre>
+ */
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
         include = As.PROPERTY,
-        property = "type",
-        visible = true
+        property = "type"
 )
 @JsonSubTypes({
         @JsonSubTypes.Type(TextMessage.class),
@@ -32,6 +40,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
         @JsonSubTypes.Type(StickerMessage.class),
         @JsonSubTypes.Type(LocationMessage.class),
         @JsonSubTypes.Type(AudioMessage.class),
+        @JsonSubTypes.Type(VideoMessage.class),
         @JsonSubTypes.Type(ImagemapMessage.class),
         @JsonSubTypes.Type(TemplateMessage.class),
 })

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/TextMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/TextMessage.java
@@ -16,11 +16,15 @@
 
 package com.linecorp.bot.model.message;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import lombok.AllArgsConstructor;
 import lombok.Value;
 
 @Value
+@AllArgsConstructor(onConstructor = @__(@JsonCreator))
+// Constructor which has only one argument needs `@JsonCreator`
 @JsonTypeName("text")
 public class TextMessage implements Message {
     private final String text;

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/TextMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/TextMessage.java
@@ -19,13 +19,17 @@ package com.linecorp.bot.model.message;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import lombok.AllArgsConstructor;
 import lombok.Value;
 
 @Value
-@AllArgsConstructor(onConstructor = @__(@JsonCreator))
-// Constructor which has only one argument needs `@JsonCreator`
 @JsonTypeName("text")
 public class TextMessage implements Message {
     private final String text;
+
+    @JsonCreator
+    // Constructor which has only one argument needs Jackson Annotation.
+    // see MessageJsonReconstructionTest for detail.
+    public TextMessage(final String text) {
+        this.text = text;
+    }
 }

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/message/MessageJsonReconstructionTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/message/MessageJsonReconstructionTest.java
@@ -1,0 +1,118 @@
+package com.linecorp.bot.model.message;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+import com.linecorp.bot.model.action.MessageAction;
+import com.linecorp.bot.model.action.PostbackAction;
+import com.linecorp.bot.model.action.URIAction;
+import com.linecorp.bot.model.message.imagemap.ImagemapBaseSize;
+import com.linecorp.bot.model.message.template.ButtonsTemplate;
+import com.linecorp.bot.model.message.template.CarouselColumn;
+import com.linecorp.bot.model.message.template.CarouselTemplate;
+import com.linecorp.bot.model.message.template.ConfirmTemplate;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Message object reconstruction test.
+ *
+ * <p>This is not a part of SDK SPEC but please check it is expected/unavoidable or not when any test is broken.
+ *
+ * <p><strong>IMPORTANT</strong>: Message serialization/deserialization by JSON is to be able to create a proof of concept in simple.
+ * This test do not intended serialization format stability. Serialized JSON format may be different depending on the version.
+ */
+@Slf4j
+public class MessageJsonReconstructionTest {
+    ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        objectMapper = new ObjectMapper()
+                .registerModule(new ParameterNamesModule());
+    }
+
+    @Test
+    public void textMessageTest() {
+        test(new TextMessage("TEST"));
+    }
+
+    @Test
+    public void stickerMessageTest() {
+        test(new StickerMessage("123", "456"));
+    }
+
+    @Test
+    public void audioMessageTest() {
+        test(new AudioMessage("originalUrl", 20));
+    }
+
+    @Test
+    public void videoMessageTest() {
+        test(new VideoMessage("https://example.com/original", "https://example.com/preview"));
+    }
+
+    @Test
+    public void imagemapMessageTest() {
+        test(new ImagemapMessage("baseUrl", "altText", new ImagemapBaseSize(1040, 1040),
+                                 emptyList()));
+    }
+
+    @Test
+    public void locationMessageTest() {
+        test(new LocationMessage("title", "address", 135.0, 0.0));
+    }
+
+    @Test
+    public void templateMessageWithCarouselTemplateTest() {
+        final PostbackAction postbackAction = new PostbackAction("postback", "data");
+        final CarouselColumn carouselColumn =
+                new CarouselColumn("thumbnail", "title", "text", singletonList(postbackAction));
+        final CarouselTemplate carouselTemplate = new CarouselTemplate(singletonList(carouselColumn));
+
+        test(new TemplateMessage("ALT", carouselTemplate));
+    }
+
+    @Test
+    public void templateMessageWithConfirmTemplateTest() {
+        final ConfirmTemplate confirmTemplate =
+                new ConfirmTemplate("text",
+                                    new URIAction("label", "http://example.com"),
+                                    new MessageAction("label", "text"));
+        test(new TemplateMessage("ALT", confirmTemplate));
+    }
+
+    @Test
+    public void templateMessageWithButtonsTemplateTest() {
+        final ButtonsTemplate buttonsTemplate =
+                new ButtonsTemplate("https://example.com", "title", "text",
+                                    singletonList(new MessageAction("label", "text")));
+        test(new TemplateMessage("ALT", buttonsTemplate));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    void test(final Message original) {
+        final Message reconstructed = serializeThenDeserialize(original);
+        assertThat(reconstructed).isEqualTo(original);
+    }
+
+    @SneakyThrows
+    Message serializeThenDeserialize(final Message original) {
+        log.info("Original:      {}", original);
+        final String asJson = objectMapper.writeValueAsString(original);
+        log.info("AS JSON:       {}", asJson);
+        final Message reconstructed = objectMapper.readValue(asJson, Message.class);
+        log.info("Reconstructed: {}", reconstructed);
+
+        return reconstructed;
+    }
+}


### PR DESCRIPTION
To creating proof of concept easily, support serializetion/deserialization for `Message` (not Event) instance.

Users can define their custom message by writing JSON and send the JSON by Messaging API before deserialize.

This PR closes https://github.com/line/line-bot-sdk-java/issues/100.