### PR TITLE
Hide network implementation libraries to users compile scope.

### DIFF
--- a/line-bot-api-client/build.gradle
+++ b/line-bot-api-client/build.gradle
@@ -18,8 +18,9 @@ dependencies {
     compile project(':line-bot-model')
     compile 'com.fasterxml.jackson.core:jackson-core'
     compile 'com.fasterxml.jackson.core:jackson-databind'
-    compile 'com.squareup.okhttp3:logging-interceptor'
-    compile 'com.squareup.retrofit2:converter-jackson'
-    compile 'com.squareup.retrofit2:retrofit'
     compile 'org.slf4j:slf4j-api'
+
+    implementation 'com.squareup.okhttp3:logging-interceptor'
+    implementation 'com.squareup.retrofit2:converter-jackson'
+    implementation 'com.squareup.retrofit2:retrofit'
 }


### PR DESCRIPTION
AS-IS
=====
Implimentation library is visible for SDK user.

TO-BE
=====
Implimentation library is not visible for SDK user.
Users who want to use Retrofit need to write dependency expressly.