### PR TITLE
Fix compile warnings and test options.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,11 +135,7 @@ subprojects {
     }
 
     compileJava {
-        options.compilerArgs << '-Xlint:all' << '-Xlint:-processing' << '-parameters'
-
-        if (!isDevBuild) {
-            options.compilerArgs << '-Werror'
-        }
+        options.compilerArgs << '-Xlint:all' << '-Werror' << '-Xlint:-processing' << '-parameters'
     }
 
     project.plugins.withType(org.springframework.boot.gradle.plugin.SpringBootPlugin) {

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingServiceBuilder.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingServiceBuilder.java
@@ -129,6 +129,7 @@ public final class LineMessagingServiceBuilder {
      *
      * @deprecated use {@link #okHttpClientBuilder(OkHttpClient.Builder, boolean)} instead.
      */
+    @Deprecated
     public LineMessagingServiceBuilder okHttpClientBuilder(
             @NonNull final OkHttpClient.Builder okHttpClientBuilder) {
         return okHttpClientBuilder(okHttpClientBuilder, false);


### PR DESCRIPTION
Change
======
All warnings are treated as error even if non-release build.

Warnings fixed.
===============
```
% ./gradlew clean uploadArchives -Pci
Starting a Gradle Daemon (subsequent builds will be faster)
:line-bot-api-client:clean
:line-bot-model:clean
:line-bot-servlet:clean
:line-bot-spring-boot:clean
:sample-spring-boot-echo:clean
:sample-spring-boot-kitchensink:clean
:line-bot-api-client:processResources NO-SOURCE
:line-bot-model:processResources NO-SOURCE
:line-bot-model:compileJava
:line-bot-model:generateGitProperties
:line-bot-model:classes
:line-bot-model:jar
:line-bot-api-client:compileJava
/Users/jp20217/github.com/line/line-bot-sdk-java-v2/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingServiceBuilder.java:132: 警告: [dep-ann] 非推奨の項目は@Deprecatedで注釈が付けられていません
    public LineMessagingServiceBuilder okHttpClientBuilder(
                                       ^
エラー: 警告が見つかり-Werrorが指定されました
エラー1個
警告1個
:line-bot-api-client:compileJava FAILED
```