### PR TITLE
Add DatatimePicker Mode enum and add make DatetimePickerAction type safe.

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/internal/DatetimePickerFieldSerializer.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/internal/DatetimePickerFieldSerializer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.internal;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.Temporal;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import com.linecorp.bot.model.action.DatetimePickerAction;
+
+/**
+ * Formatter for {@link DatetimePickerAction} format.
+ *
+ * @see <a href="https://developers.line.biz/en/docs/messaging-api/actions/#datetime-picker-action">//developers.line.biz/en/docs/messaging-api/actions/#datetime-picker-action</a>
+ */
+public class DatetimePickerFieldSerializer extends JsonSerializer<Temporal> {
+    // no ":ss"
+    private static final DateTimeFormatter DATETIMEPICKER_LOCAL_TIME =
+            DateTimeFormatter.ofPattern("HH:mm");
+    private static final DateTimeFormatter DATETIMEPICKER_LOCAL_DATETIME =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
+
+    @Override
+    public void serialize(final Temporal value, final JsonGenerator gen, final SerializerProvider serializers)
+            throws IOException, JsonProcessingException {
+        gen.writeString(serialize(value));
+    }
+
+    String serialize(final Temporal value) {
+        if (value instanceof LocalTime) {
+            return DATETIMEPICKER_LOCAL_TIME.format(value);
+        } else if (value instanceof LocalDate) {
+            return DateTimeFormatter.ISO_LOCAL_DATE.format(value);
+        } else if (value instanceof LocalDateTime) {
+            return DATETIMEPICKER_LOCAL_DATETIME.format(value);
+        } else {
+            throw new IllegalArgumentException("Illegal value type: " + value.getClass());
+        }
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/action/DatetimePickerAction.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/action/DatetimePickerAction.java
@@ -16,13 +16,22 @@
 
 package com.linecorp.bot.model.action;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.Temporal;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
+import com.linecorp.bot.internal.DatetimePickerFieldSerializer;
+
+import lombok.Builder;
 import lombok.Value;
 
 /**
@@ -30,12 +39,75 @@ import lombok.Value;
  *
  * <p>When this action is tapped, a postback event is returned via webhook
  * with the date and time selected by the user from the date and time selection dialog.
+ *
+ * <p>To create instance of this class, use
+ * {@link DatetimePickerAction.OfLocalTime#builder()},
+ * {@link DatetimePickerAction.OfLocalDate#builder()}
+ * or {@link DatetimePickerAction.OfLocalDatetime#builder()}.
+ *
+ * @see <a href="https://developers.line.biz/en/docs/messaging-api/actions/#datetime-picker-action">//developers.line.biz/en/docs/messaging-api/actions/#datetime-picker-action</a>
  */
-@Value
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName("datetimepicker")
 @JsonInclude(Include.NON_NULL)
-public class DatetimePickerAction implements Action {
+public interface DatetimePickerAction<T extends Temporal> extends Action {
+    /**
+     * DatetimePicker pick mode.
+     */
+    enum Mode {
+        @JsonProperty("date")
+        DATE,
+        @JsonProperty("time")
+        TIME,
+        @JsonProperty("datetime")
+        DATETIME,
+    }
+
+    @Value
+    @Builder
+    class OfLocalDate implements DatetimePickerAction<LocalDate> {
+        @Override
+        public Mode getMode() {
+            return Mode.DATE;
+        }
+
+        String label;
+        String data;
+        LocalDate initial;
+        LocalDate min;
+        LocalDate max;
+    }
+
+    @Value
+    @Builder
+    class OfLocalTime implements DatetimePickerAction<LocalTime> {
+        @Override
+        public Mode getMode() {
+            return Mode.TIME;
+        }
+
+        String label;
+        String data;
+        LocalTime initial;
+        LocalTime min;
+        LocalTime max;
+    }
+
+    @Value
+    @Builder
+    class OfLocalDatetime implements DatetimePickerAction<LocalDateTime> {
+        @Override
+        public Mode getMode() {
+            return Mode.DATETIME;
+        }
+
+        String label;
+        String data;
+        LocalDateTime initial;
+        LocalDateTime min;
+        LocalDateTime max;
+    }
+
     /**
      * Label for the action.
      *
@@ -44,42 +116,42 @@ public class DatetimePickerAction implements Action {
      * <li>Optional for image carousel templates. Max: 12 characters.</li>
      * </ul>
      */
-    private final String label;
+    @Override
+    String getLabel();
 
     /**
      * String returned via webhook in the postback.data property of the postback event.
      *
      * <p>Max: 300 characters
      */
-    private final String data;
+    String getData();
 
     /**
      * Action mode.
      *
-     * <ul>
-     * <li>date: Pick date
-     * <li>time: Pick time
-     * <li>datetime: Pick date and time
-     * </ul>
+     * @see Mode
      */
-    private final String mode;
+    Mode getMode();
 
     /**
      * Initial value of date or time.
      */
-    private final String initial;
+    @JsonSerialize(using = DatetimePickerFieldSerializer.class)
+    T getInitial();
 
     /**
      * Largest date or time value that can be selected.
      * Must be greater than the min value.
      */
-    private final String max;
+    @JsonSerialize(using = DatetimePickerFieldSerializer.class)
+    T getMax();
 
     /**
      * Smallest date or time value that can be selected.
      * Must be less than the max value.
      */
-    private final String min;
+    @JsonSerialize(using = DatetimePickerFieldSerializer.class)
+    T getMin();
 
     /**
      * Create new instance.
@@ -93,24 +165,53 @@ public class DatetimePickerAction implements Action {
      *         Must be greater than the min value. (optional)
      * @param min Smallest date or time value that can be selected.
      *         Must be less than the max value. (optional)
+     *
+     * @deprecated This method intended to used in deserialize json object.
+     *     Use {@link DatetimePickerAction.OfLocalTime#builder()},
+     *     {@link DatetimePickerAction.OfLocalDate#builder()}
+     *     or {@link DatetimePickerAction.OfLocalDatetime#builder()}.
      */
     @JsonCreator
-    public DatetimePickerAction(
-            @JsonProperty("label") String label,
-            @JsonProperty("data") String data,
-            @JsonProperty("mode") String mode,
-            @JsonProperty("initial") String initial,
-            @JsonProperty("max") String max,
-            @JsonProperty("min") String min) {
-        this.label = label;
-        this.data = data;
-        this.mode = mode;
-        this.initial = initial;
-        this.max = max;
-        this.min = min;
-    }
+    @Deprecated
+    static DatetimePickerAction<?> parse(
+            @JsonProperty("label") final String label,
+            @JsonProperty("data") final String data,
+            @JsonProperty("mode") final Mode mode,
+            @JsonProperty("initial") final String initial,
+            @JsonProperty("max") final String max,
+            @JsonProperty("min") final String min) {
+        switch (mode) {
+            case DATE:
+                return OfLocalDate
+                        .builder()
+                        .label(label)
+                        .data(data)
+                        .initial(initial != null ? LocalDate.parse(initial) : null)
+                        .max(initial != null ? LocalDate.parse(max) : null)
+                        .min(initial != null ? LocalDate.parse(min) : null)
+                        .build();
 
-    public DatetimePickerAction(String label, String data, String mode) {
-        this(label, data, mode, null, null, null);
+            case TIME:
+                return OfLocalTime
+                        .builder()
+                        .label(label)
+                        .data(data)
+                        .initial(initial != null ? LocalTime.parse(initial) : null)
+                        .max(initial != null ? LocalTime.parse(max) : null)
+                        .min(initial != null ? LocalTime.parse(min) : null)
+                        .build();
+
+            case DATETIME:
+                return OfLocalDatetime
+                        .builder()
+                        .label(label)
+                        .data(data)
+                        .initial(initial != null ? LocalDateTime.parse(initial) : null)
+                        .max(initial != null ? LocalDateTime.parse(max) : null)
+                        .min(initial != null ? LocalDateTime.parse(min) : null)
+                        .build();
+        }
+
+        throw new UnsupportedOperationException("Unknown mode: " + mode);
     }
 }

--- a/line-bot-model/src/test/java/com/linecorp/bot/internal/DatetimePickerFieldSerializerTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/internal/DatetimePickerFieldSerializerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import org.junit.Test;
+
+public class DatetimePickerFieldSerializerTest {
+    final DatetimePickerFieldSerializer target = new DatetimePickerFieldSerializer();
+
+    @Test
+    public void localDateSerializeTest() throws Exception {
+        assertThat(target.serialize(LocalDate.of(2017, 9, 8)))
+                .isEqualTo("2017-09-08");
+    }
+
+    @Test
+    public void localTimeSerializeTest() throws Exception {
+        assertThat(target.serialize(LocalTime.of(15, 52)))
+                .isEqualTo("15:52");
+    }
+
+    @Test
+    public void localDatetimeSerializeTest() throws Exception {
+        assertThat(target.serialize(LocalDateTime.of(2017, 9, 8, 15, 52)))
+                .isEqualToIgnoringCase("2017-09-08T15:52");
+    }
+
+    @Test
+    public void unsupportedTypeSerializeTest() throws Exception {
+        assertThatThrownBy(() -> {
+            target.serialize(Instant.now());
+        }).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/message/MessageJsonReconstructionTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/message/MessageJsonReconstructionTest.java
@@ -23,17 +23,25 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.bot.model.Broadcast;
 import com.linecorp.bot.model.Multicast;
 import com.linecorp.bot.model.action.CameraAction;
 import com.linecorp.bot.model.action.CameraRollAction;
+import com.linecorp.bot.model.action.DatetimePickerAction;
+import com.linecorp.bot.model.action.DatetimePickerAction.OfLocalDate;
+import com.linecorp.bot.model.action.DatetimePickerAction.OfLocalDatetime;
+import com.linecorp.bot.model.action.DatetimePickerAction.OfLocalTime;
 import com.linecorp.bot.model.action.LocationAction;
 import com.linecorp.bot.model.action.MessageAction;
 import com.linecorp.bot.model.action.PostbackAction;
@@ -183,6 +191,42 @@ public class MessageJsonReconstructionTest {
         final Broadcast broadcast = new Broadcast(singletonList(new TextMessage("text")), true);
 
         test(broadcast);
+    }
+
+    @Test
+    public void datetimePickerActionTest() {
+        final DatetimePickerAction<LocalDate> datePickerAction =
+                OfLocalDate.builder()
+                           .label("labal")
+                           .data("postback")
+                           .initial(LocalDate.of(2017, 9, 8))
+                           .min(LocalDate.of(2017, 9, 8))
+                           .max(LocalDate.of(2017, 9, 8))
+                           .build();
+
+        final DatetimePickerAction<LocalTime> timePickerAction =
+                OfLocalTime.builder()
+                           .label("labal")
+                           .data("postback")
+                           .initial(LocalTime.of(14, 55))
+                           .max(LocalTime.of(14, 55))
+                           .min(LocalTime.of(14, 55))
+                           .build();
+
+        final DatetimePickerAction<LocalDateTime> datetimePickerAction =
+                OfLocalDatetime.builder()
+                               .label("labal")
+                               .data("postback")
+                               .initial(LocalDateTime.of(2017, 9, 8, 14, 55))
+                               .max(LocalDateTime.of(2017, 9, 8, 14, 55))
+                               .min(LocalDateTime.of(2017, 9, 8, 14, 55))
+                               .build();
+
+        final ButtonsTemplate buttonsTemplate =
+                new ButtonsTemplate(URI.create("https://example.com"), "title", "text",
+                                    ImmutableList.of(datePickerAction, timePickerAction, datetimePickerAction));
+
+        test(new TemplateMessage("ALT_TEXT", buttonsTemplate));
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/KitchenSinkController.java
+++ b/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/KitchenSinkController.java
@@ -22,7 +22,9 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -233,15 +235,15 @@ public class KitchenSinkController {
     public void handleMemberJoined(MemberJoinedEvent event) {
         String replyToken = event.getReplyToken();
         this.replyText(replyToken, "Got memberJoined message " + event.getJoined().getMembers()
-                .stream().map(Source::getUserId)
-                .collect(Collectors.joining(",")));
+                                                                      .stream().map(Source::getUserId)
+                                                                      .collect(Collectors.joining(",")));
     }
 
     @EventMapping
     public void handleMemberLeft(MemberLeftEvent event) {
         log.info("Got memberLeft message: {}", event.getLeft().getMembers()
-                .stream().map(Source::getUserId)
-                .collect(Collectors.joining(",")));
+                                                    .stream().map(Source::getUserId)
+                                                    .collect(Collectors.joining(",")));
     }
 
     @EventMapping
@@ -414,24 +416,30 @@ public class KitchenSinkController {
                                 )),
                                 new CarouselColumn(imageUrl, "Datetime Picker",
                                                    "Please select a date, time or datetime", Arrays.asList(
-                                        new DatetimePickerAction("Datetime",
-                                                                 "action=sel",
-                                                                 "datetime",
-                                                                 "2017-06-18T06:15",
-                                                                 "2100-12-31T23:59",
-                                                                 "1900-01-01T00:00"),
-                                        new DatetimePickerAction("Date",
-                                                                 "action=sel&only=date",
-                                                                 "date",
-                                                                 "2017-06-18",
-                                                                 "2100-12-31",
-                                                                 "1900-01-01"),
-                                        new DatetimePickerAction("Time",
-                                                                 "action=sel&only=time",
-                                                                 "time",
-                                                                 "06:15",
-                                                                 "23:59",
-                                                                 "00:00")
+                                        DatetimePickerAction.OfLocalDatetime
+                                                .builder()
+                                                .label("Datetime")
+                                                .data("action=sel")
+                                                .initial(LocalDateTime.parse("2017-06-18T06:15"))
+                                                .min(LocalDateTime.parse("1900-01-01T00:00"))
+                                                .max(LocalDateTime.parse("2100-12-31T23:59"))
+                                                .build(),
+                                        DatetimePickerAction.OfLocalDate
+                                                .builder()
+                                                .label("Date")
+                                                .data("action=sel&only=date")
+                                                .initial(LocalDate.parse("2017-06-18"))
+                                                .min(LocalDate.parse("1900-01-01"))
+                                                .max(LocalDate.parse("2100-12-31"))
+                                                .build(),
+                                        DatetimePickerAction.OfLocalTime
+                                                .builder()
+                                                .label("Time")
+                                                .data("action=sel&only=time")
+                                                .initial(LocalTime.parse("06:15"))
+                                                .min(LocalTime.parse("00:00"))
+                                                .max(LocalTime.parse("23:59"))
+                                                .build()
                                 ))
                         ));
                 TemplateMessage templateMessage = new TemplateMessage("Carousel alt text", carouselTemplate);


### PR DESCRIPTION
AS-IS
* Mode of DatatimePickerAction (time, date or datetime) is represented by String field `#mode`.

TO-BE
* Created `Mode` enum.
* `DatetimePickerAction` is interface and 3 implementation (Time, Date, Datetimea) represents type of DatatimePickerAction.