### PR TITLE
Support new options for template message images

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/ButtonsTemplate.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/ButtonsTemplate.java
@@ -25,12 +25,17 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import com.linecorp.bot.model.action.Action;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 /**
  * Template message with an image, title, text, and multiple action buttons.
  */
 @Value
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonTypeName("buttons")
 public class ButtonsTemplate implements Template {
     /**
@@ -45,6 +50,37 @@ public class ButtonsTemplate implements Template {
      * </ul>
      */
     private final String thumbnailImageUrl;
+
+    /**
+     * Aspect ratio of the image. Specify one of the following values:
+     *
+     * <ul>
+     *     <li>rectangle: 1.51:1</li>
+     *     <li>square: 1:1</li>
+     * </ul>
+     *
+     * The default value is {@code rectangle}.
+     */
+    private final String imageAspectRatio;
+
+    /**
+     * Size of the image. Specify one of the following values:
+     *
+     * <ul>
+     *     <li>cover: The image fills the entire image area. Parts of the image that do not fit in the area are not displayed.</li>
+     *     <li>contain: The entire image is displayed in the image area. A background is displayed in the unused areas to the left and right of vertical images and in the areas above and below horizontal images.</li>
+     * </ul>
+     *
+     * The default value is {@code cover}.
+     */
+    private final String imageSize;
+
+    /**
+     * Background color of image.
+     *
+     * <p>Specify a RGB color value. The default value is {@code #FFFFFF} (white).
+     */
+    private final String imageBackgroundColor;
 
     /**
      * Title(Max 40 characters)
@@ -76,5 +112,8 @@ public class ButtonsTemplate implements Template {
         this.title = title;
         this.text = text;
         this.actions = actions != null ? actions : Collections.emptyList();
+        this.imageAspectRatio = null;
+        this.imageSize = null;
+        this.imageBackgroundColor = null;
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/CarouselColumn.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/CarouselColumn.java
@@ -24,12 +24,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.linecorp.bot.model.action.Action;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 /**
  * Column object for carousel template
+ *
+ * @see CarouselColumnBuilder
  */
 @Value
+@Builder
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class CarouselColumn {
     /**
      * Image URL
@@ -42,6 +49,13 @@ public class CarouselColumn {
      * </ul>
      */
     private final String thumbnailImageUrl;
+
+    /**
+     * Background color of image.
+     *
+     * <p>Specify a RGB color value. The default value is <code>#FFFFFF</code> (white).
+     */
+    private final String imageBackgroundColor;
 
     /**
      * Title (Max: 40 characters)
@@ -70,5 +84,6 @@ public class CarouselColumn {
         this.title = title;
         this.text = text;
         this.actions = actions != null ? actions : Collections.emptyList();
+        this.imageBackgroundColor = null;
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/CarouselTemplate.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/CarouselTemplate.java
@@ -22,12 +22,19 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 /**
  * Template message with multiple columns which can be cycled like a carousel.
+ *
+ * @see CarouselTemplateBuilder
  */
 @Value
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonTypeName("carousel")
 public class CarouselTemplate implements Template {
     /**
@@ -35,8 +42,34 @@ public class CarouselTemplate implements Template {
      */
     private final List<CarouselColumn> columns;
 
+    /**
+     * Aspect ratio of the image. Specify one of the following values:
+     *
+     * <ul>
+     *     <li>rectangle: 1.51:1</li>
+     *     <li>square: 1:1</li>
+     * </ul>
+     *
+     * The default value is {@code rectangle}.
+     */
+    private final String imageAspectRatio;
+
+    /**
+     * Size of the image. Specify one of the following values:
+     *
+     * <ul>
+     *     <li>cover: The image fills the entire image area. Parts of the image that do not fit in the area are not displayed.</li>
+     *     <li>contain: The entire image is displayed in the image area. A background is displayed in the unused areas to the left and right of vertical images and in the areas above and below horizontal images.</li>
+     * </ul>
+     *
+     * The default value is {@code cover}.
+     */
+    private final String imageSize;
+
     @JsonCreator
     public CarouselTemplate(@JsonProperty("columns") List<CarouselColumn> columns) {
         this.columns = columns;
+        this.imageAspectRatio = null;
+        this.imageSize = null;
     }
 }


### PR DESCRIPTION
> We have released imageAspectRatio, imageSize, and imageBackgroundColor fields for Buttons and Carousel template messages. Using these fields, you can configure the aspect ratio, size, and background color for images used in template messages.

* https://github.com/line/line-bot-sdk-java/issues/162
* https://developers.line.me/en/news/2017/11/

policy
====
* Use Builder (Add `@Builder` annotation)