### PR TITLE
Fix javadoc issue.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ buildscript {
         classpath 'io.spring.gradle:dependency-management-plugin:1.0.4.RELEASE'
         classpath 'io.spring.gradle:propdeps-plugin:0.0.9.RELEASE'
         classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.5.9.RELEASE'
+        classpath 'io.franzbecker:gradle-lombok:1.6'
     }
 }
 
@@ -61,6 +62,7 @@ subprojects {
     apply plugin: 'propdeps-eclipse'
     apply plugin: 'findbugs'
     apply plugin: 'java'
+    apply plugin: 'io.franzbecker.gradle-lombok'
     if (new File("${project.rootDir}/.git").exists()) {
         logger.info("There's .git directory. Create git.properties.")
         apply plugin: 'com.gorylenko.gradle-git-properties'
@@ -119,13 +121,33 @@ subprojects {
         }
     }
 
+    lombok {
+        version = '1.16.18'
+    }
+
     if (!project.name.startsWith('sample-')) {
-        task javadocJar(type: Jar) {
-            classifier = 'javadoc'
-            from "${buildDir}/javadoc"
+        task delombok(type: io.franzbecker.gradle.lombok.task.DelombokTask, dependsOn: compileJava) {
+            ext.outputDir = file("$buildDir/delombok")
+            outputs.dir(outputDir)
+            sourceSets.main.java.srcDirs.each {
+                inputs.dir(it)
+                args(it, "-d", outputDir)
+            }
         }
 
-        task sourcesJar(type: Jar) {
+        javadoc {
+            dependsOn delombok
+            source = delombok.outputDir
+            options.addStringOption('Xdoclint:none', '-quiet')
+            // To create javadoc for generated method&constructor, delombok & run javadoc on delombok.outputDir.
+        }
+
+        task javadocJar(type: Jar, dependsOn: 'javadoc') {
+            classifier = 'javadoc'
+            from javadoc.destinationDir
+        }
+
+        task sourcesJar(type: Jar, dependsOn: 'classes') {
             classifier = 'sources'
             from sourceSets.main.allSource
         }

--- a/line-bot-api-client/build.gradle
+++ b/line-bot-api-client/build.gradle
@@ -23,6 +23,5 @@ dependencies {
     compile 'com.squareup.okhttp3:logging-interceptor'
     compile 'com.squareup.retrofit2:converter-jackson'
     compile 'com.squareup.retrofit2:retrofit'
-
-    optional 'org.slf4j:slf4j-api'
+    compile 'org.slf4j:slf4j-api'
 }

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotProperties.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotProperties.java
@@ -93,7 +93,7 @@ public class LineBotProperties {
     public static class Handler {
         /**
          * Flag to enable/disable {@link LineMessageHandler} and {@link EventMapping}.
-         *
+         * <p>
          * Default: {@code true}
          */
         boolean enabled = true;
@@ -105,7 +105,7 @@ public class LineBotProperties {
         URI path = URI.create("/callback");
     }
 
-    enum ChannelTokenSupplyMode {
+    public enum ChannelTokenSupplyMode {
         /**
          * Use fixed channel token for public API user.
          */


### PR DESCRIPTION
https://github.com/line/line-bot-sdk-java/issues/173

Core Change
===
* `javadocJar` should be depends on `javadoc` task

AS-IS
=====
```
% gradle clean assemble; ll **/*-javadoc.jar
line-bot-sdk-java

BUILD SUCCESSFUL in 7s
39 actionable tasks: 39 executed
-rw-r--r--  1 JP20217  staff  261  1 19 17:37 line-bot-api-client/build/libs/line-bot-api-client-1.15.0-SNAPSHOT-javadoc.jar
-rw-r--r--  1 JP20217  staff  261  1 19 17:37 line-bot-model/build/libs/line-bot-model-1.15.0-SNAPSHOT-javadoc.jar
-rw-r--r--  1 JP20217  staff  261  1 19 17:37 line-bot-servlet/build/libs/line-bot-servlet-1.15.0-SNAPSHOT-javadoc.jar
-rw-r--r--  1 JP20217  staff  261  1 19 17:37 line-bot-spring-boot/build/libs/line-bot-spring-boot-1.15.0-SNAPSHOT-javadoc.jar
```

TO-BE
=====
```
% gradle clean assemble; ll **/*-javadoc.jar
line-bot-sdk-java

> Task :line-bot-model:javadoc
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-model/build/delombok/com/linecorp/bot/model/event/ReplyEvent.java:17: 警告 - タグ@see: 閉じタグ'>'がありません: "<a href="https://devdocs.line.me/#reply-message">//devdocs.line.me/#reply-message</a> &gt; Request Body"
警告1個

> Task :line-bot-api-client:javadoc
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-api-client/build/delombok/com/linecorp/bot/client/LineMessagingClientBuilder.java:106: 警告 - タグ@link: 参照が見つかりません: OkHttpClient.Builder
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-api-client/build/delombok/com/linecorp/bot/client/LineMessagingClientBuilder.java:119: 警告 - タグ@link: 参照が見つかりません: Retrofit.Builder
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-api-client/build/delombok/com/linecorp/bot/client/LineMessagingClientBuilder.java:92: 警告 - タグ@link: 参照が見つかりません: OkHttpClient.Builder
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-api-client/build/delombok/com/linecorp/bot/client/LineMessagingClientBuilder.java:106: 警告 - タグ@link: 参照が見つかりません: OkHttpClient.Builder
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-api-client/build/delombok/com/linecorp/bot/client/LineMessagingClientBuilder.java:119: 警告 - タグ@link: 参照が見つかりません: Retrofit.Builder
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-api-client/build/delombok/com/linecorp/bot/client/LineMessagingServiceBuilder.java:151: 警告 - タグ@link: 参照が見つかりません: OkHttpClient.Builder
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-api-client/build/delombok/com/linecorp/bot/client/LineMessagingServiceBuilder.java:167: 警告 - タグ@link: 参照が見つかりません: Retrofit.Builder
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-api-client/build/delombok/com/linecorp/bot/client/LineMessagingServiceBuilder.java:138: 警告 - タグ@link: 参照が見つかりません: OkHttpClient.Builder
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-api-client/build/delombok/com/linecorp/bot/client/LineMessagingServiceBuilder.java:151: 警告 - タグ@link: 参照が見つかりません: OkHttpClient.Builder
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-api-client/build/delombok/com/linecorp/bot/client/LineMessagingServiceBuilder.java:167: 警告 - タグ@link: 参照が見つかりません: Retrofit.Builder
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-api-client/build/delombok/com/linecorp/bot/client/LineMessagingClientBuilder.java:106: 警告 - タグ@link: 参照が見つかりません: OkHttpClient.Builder
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-api-client/build/delombok/com/linecorp/bot/client/LineMessagingServiceBuilder.java:151: 警告 - タグ@link: 参照が見つかりません: OkHttpClient.Builder
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-api-client/build/delombok/com/linecorp/bot/client/LineMessagingClientBuilder.java:119: 警告 - タグ@link: 参照が見つかりません: Retrofit.Builder
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-api-client/build/delombok/com/linecorp/bot/client/LineMessagingServiceBuilder.java:167: 警告 - タグ@link: 参照が見つかりません: Retrofit.Builder
警告14個

> Task :line-bot-servlet:delombok
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-servlet/src/main/java/com/linecorp/bot/servlet/LineBotCallbackRequestParser.java:22: エラー: パッケージjavax.servlet.httpは存在しません
import javax.servlet.http.HttpServletRequest;
                         ^
/Users/JP20217/github.com/line/line-bot-sdk-java/line-bot-servlet/src/main/java/com/linecorp/bot/servlet/LineBotCallbackRequestParser.java:58: エラー: シンボルを見つけられません
    public CallbackRequest handle(HttpServletRequest req) throws LineBotCallbackException, IOException {
                                  ^
  シンボル:   クラス HttpServletRequest
  場所: クラス LineBotCallbackRequestParser

BUILD SUCCESSFUL in 25s
55 actionable tasks: 55 executed
-rw-r--r--  1 JP20217  staff   92817  1 19 17:38 line-bot-api-client/build/libs/line-bot-api-client-1.15.0-SNAPSHOT-javadoc.jar
-rw-r--r--  1 JP20217  staff  314385  1 19 17:38 line-bot-model/build/libs/line-bot-model-1.15.0-SNAPSHOT-javadoc.jar
-rw-r--r--  1 JP20217  staff   26311  1 19 17:38 line-bot-servlet/build/libs/line-bot-servlet-1.15.0-SNAPSHOT-javadoc.jar
-rw-r--r--  1 JP20217  staff   79313  1 19 17:38 line-bot-spring-boot/build/libs/line-bot-spring-boot-1.15.0-SNAPSHOT-javadoc.jar
-rw-r--r--  1 JP20217  staff   22016  1 19 17:38 sample-spring-boot-echo/build/libs/sample-spring-boot-echo-1.15.0-SNAPSHOT-javadoc.jar
-rw-r--r--  1 JP20217  staff   31849  1 19 17:38 sample-spring-boot-kitchensink/build/libs/sample-spring-boot-kitchensink-1.15.0-SNAPSHOT-javadoc.jar
```