### PR TITLE
Flex message support

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/FlexMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/FlexMessage.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import com.linecorp.bot.model.message.flex.container.FlexContainer;
+
+import lombok.Value;
+
+/**
+ * Flex message is a message type that allows for building informative message which consists of texts,
+ * buttons, images, etc.
+ */
+@Value
+@JsonTypeName("flex")
+public class FlexMessage implements Message {
+    /**
+     * Alternative text
+     */
+    private final String altText;
+
+    /**
+     * Object with the contents of the flex.
+     */
+    private final FlexContainer contents;
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Box.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Box.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.component;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import com.linecorp.bot.model.action.Action;
+import com.linecorp.bot.model.message.flex.unit.FxLayout;
+import com.linecorp.bot.model.message.flex.unit.FxMarginSize;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@JsonTypeName("box")
+@JsonInclude(Include.NON_NULL)
+public class Box implements FlexComponent {
+
+    private final FxLayout layout;
+
+    private final Integer flex;
+
+    private final List<FlexComponent> contents;
+
+    private final FxMarginSize spacing;
+
+    private final FxMarginSize margin;
+
+    private final Action action;
+
+    @JsonCreator
+    public Box(
+            @JsonProperty("layout") FxLayout layout,
+            @JsonProperty("flex") Integer flex,
+            @JsonProperty("contents") List<FlexComponent> contents,
+            @JsonProperty("spacing") FxMarginSize spacing,
+            @JsonProperty("margin") FxMarginSize margin,
+            @JsonProperty("action") Action action) {
+        this.layout = layout;
+        this.flex = flex;
+        this.contents = contents != null ? contents : Collections.emptyList();
+        this.spacing = spacing;
+        this.margin = margin;
+        this.action = action;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Button.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Button.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.component;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import com.linecorp.bot.model.action.Action;
+import com.linecorp.bot.model.message.flex.unit.FxGravity;
+import com.linecorp.bot.model.message.flex.unit.FxMarginSize;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@JsonTypeName("button")
+@JsonInclude(Include.NON_NULL)
+public class Button implements FlexComponent {
+
+    public enum ButtonStyle {
+        @JsonProperty("primary")
+        Primary,
+        @JsonProperty("secondary")
+        Secondary,
+        @JsonProperty("link")
+        Link,
+    }
+
+    public enum ButtonHeight {
+        @JsonProperty("md")
+        Medium,
+        @JsonProperty("sm")
+        Small,
+    }
+
+    private Integer flex;
+
+    private String color;
+
+    private ButtonStyle style;
+
+    private Action action;
+
+    private FxGravity gravity;
+
+    private FxMarginSize margin;
+
+    private ButtonHeight height;
+
+    @JsonCreator
+    public Button(
+            @JsonProperty("flex") Integer flex,
+            @JsonProperty("color") String color,
+            @JsonProperty("style") ButtonStyle style,
+            @JsonProperty("action") Action action,
+            @JsonProperty("gravity") FxGravity gravity,
+            @JsonProperty("margin") FxMarginSize margin,
+            @JsonProperty("height") ButtonHeight height) {
+        this.flex = flex;
+        this.color = color;
+        this.style = style;
+        this.action = action;
+        this.gravity = gravity;
+        this.margin = margin;
+        this.height = height;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Filler.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Filler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.component;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import lombok.Value;
+
+@Value
+@JsonTypeName("filler")
+public class Filler implements FlexComponent {
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/FlexComponent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/FlexComponent.java
@@ -14,36 +14,26 @@
  * under the License.
  */
 
-package com.linecorp.bot.model.message;
+package com.linecorp.bot.model.message.flex.component;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 
-/**
- * Interface of Message object.
- *
- * <h2>JSON Deserialization</h2>
- *
- * <p>If you want serialize/deserialize of this object, please use Jackson's ObjectMapper with
- *
- * <pre>.registerModule(new <a href="https://github.com/FasterXML/jackson-modules-java8/tree/master/parameter-names">ParameterNamesModule</a>());</pre>
- */
+@JsonSubTypes({
+        @JsonSubTypes.Type(Text.class),
+        @JsonSubTypes.Type(Image.class),
+        @JsonSubTypes.Type(Box.class),
+        @JsonSubTypes.Type(Separator.class),
+        @JsonSubTypes.Type(Filler.class),
+        @JsonSubTypes.Type(Button.class),
+        @JsonSubTypes.Type(Icon.class),
+        @JsonSubTypes.Type(Spacer.class),
+})
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
         include = As.PROPERTY,
         property = "type"
 )
-@JsonSubTypes({
-        @JsonSubTypes.Type(TextMessage.class),
-        @JsonSubTypes.Type(ImageMessage.class),
-        @JsonSubTypes.Type(StickerMessage.class),
-        @JsonSubTypes.Type(LocationMessage.class),
-        @JsonSubTypes.Type(AudioMessage.class),
-        @JsonSubTypes.Type(VideoMessage.class),
-        @JsonSubTypes.Type(ImagemapMessage.class),
-        @JsonSubTypes.Type(TemplateMessage.class),
-        @JsonSubTypes.Type(FlexMessage.class),
-})
-public interface Message {
+public interface FlexComponent {
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Icon.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Icon.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.component;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import com.linecorp.bot.model.message.flex.unit.FxFontSize;
+import com.linecorp.bot.model.message.flex.unit.FxMarginSize;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@JsonTypeName("icon")
+@JsonInclude(Include.NON_NULL)
+public class Icon implements FlexComponent {
+
+    public enum IconAspectRatio {
+        @JsonProperty("1:1")
+        R1to1,
+        @JsonProperty("2:1")
+        R2to1,
+        @JsonProperty("3:1")
+        R3to1,
+    }
+
+    private final String url;
+
+    private final FxFontSize size;
+
+    private final IconAspectRatio aspectRatio;
+
+    private final FxMarginSize margin;
+
+    @JsonCreator
+    public Icon(
+            @JsonProperty("url") String url,
+            @JsonProperty("size") FxFontSize size,
+            @JsonProperty("aspectRatio") IconAspectRatio aspectRatio,
+            @JsonProperty("margin") FxMarginSize margin) {
+        this.url = url;
+        this.size = size;
+        this.aspectRatio = aspectRatio;
+        this.margin = margin;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Image.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Image.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.component;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import com.linecorp.bot.model.action.Action;
+import com.linecorp.bot.model.message.flex.unit.FxAlign;
+import com.linecorp.bot.model.message.flex.unit.FxGravity;
+import com.linecorp.bot.model.message.flex.unit.FxMarginSize;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@JsonTypeName("image")
+@JsonInclude(Include.NON_NULL)
+public class Image implements FlexComponent {
+
+    public enum ImageSize {
+        @JsonProperty("xxs")
+        XXs,
+        @JsonProperty("xs")
+        Xs,
+        @JsonProperty("sm")
+        Sm,
+        @JsonProperty("md")
+        Md,
+        @JsonProperty("lg")
+        Lg,
+        @JsonProperty("xl")
+        Xl,
+        @JsonProperty("xxl")
+        XXl,
+        @JsonProperty("3xl")
+        XXXl,
+        @JsonProperty("4xl")
+        XXXXl,
+        @JsonProperty("5xl")
+        XXXXXl,
+        @JsonProperty("full")
+        FullWidth,
+    }
+
+    public enum ImageAspectRatio {
+        @JsonProperty("1:1")
+        R1to1,
+        @JsonProperty("20:13")
+        R20to13,
+        @JsonProperty("1.91:1")
+        R1_91to1,
+        @JsonProperty("4:3")
+        R4to3,
+        @JsonProperty("16:9")
+        R16to9,
+        @JsonProperty("2:1")
+        R2to1,
+        @JsonProperty("3:1")
+        R3to1,
+        @JsonProperty("3:4")
+        R3to4,
+        @JsonProperty("9:16")
+        R9to16,
+        @JsonProperty("1:2")
+        R1to2,
+        @JsonProperty("1:3")
+        R1to3,
+        @JsonProperty("1.51:1")
+        R1_51to1,
+        @JsonProperty("1:1.55")
+        R1to1_55,
+    }
+
+    public enum ImageAspectMode {
+        @JsonProperty("fit")
+        Fit,
+        @JsonProperty("cover")
+        Cover,
+    }
+
+    private final Integer flex;
+
+    private final String url;
+
+    private final ImageSize size;
+
+    private final ImageAspectRatio aspectRatio;
+
+    private final ImageAspectMode aspectMode;
+
+    private final String backgroundColor;
+
+    private final FxAlign align;
+
+    private final Action action;
+
+    private final FxGravity gravity;
+
+    private final FxMarginSize margin;
+
+    @JsonCreator
+    public Image(
+            @JsonProperty("flex") Integer flex,
+            @JsonProperty("url") String url,
+            @JsonProperty("size") ImageSize size,
+            @JsonProperty("aspectRatio") ImageAspectRatio aspectRatio,
+            @JsonProperty("aspectMode") ImageAspectMode aspectMode,
+            @JsonProperty("backgroundColor") String backgroundColor,
+            @JsonProperty("align") FxAlign align,
+            @JsonProperty("action") Action action,
+            @JsonProperty("gravity") FxGravity gravity,
+            @JsonProperty("margin") FxMarginSize margin) {
+        this.flex = flex;
+        this.url = url;
+        this.size = size;
+        this.aspectRatio = aspectRatio;
+        this.aspectMode = aspectMode;
+        this.backgroundColor = backgroundColor;
+        this.align = align;
+        this.action = action;
+        this.gravity = gravity;
+        this.margin = margin;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Separator.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Separator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.component;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import com.linecorp.bot.model.message.flex.unit.FxMarginSize;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@JsonTypeName("separator")
+@JsonInclude(Include.NON_NULL)
+public class Separator implements FlexComponent {
+
+    private final FxMarginSize margin;
+
+    private final String color;
+
+    @JsonCreator
+    public Separator(
+            @JsonProperty("margin") FxMarginSize margin,
+            @JsonProperty("color") String color) {
+        this.margin = margin;
+        this.color = color;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Spacer.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Spacer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.component;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import com.linecorp.bot.model.message.flex.unit.FxMarginSize;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@JsonTypeName("spacer")
+@JsonInclude(Include.NON_NULL)
+public class Spacer implements FlexComponent {
+
+    private final FxMarginSize size;
+
+    @JsonCreator
+    public Spacer(
+            @JsonProperty("size") FxMarginSize size) {
+        this.size = size;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Text.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Text.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.component;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import com.linecorp.bot.model.action.Action;
+import com.linecorp.bot.model.message.flex.unit.FxAlign;
+import com.linecorp.bot.model.message.flex.unit.FxFontSize;
+import com.linecorp.bot.model.message.flex.unit.FxGravity;
+import com.linecorp.bot.model.message.flex.unit.FxMarginSize;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@JsonTypeName("text")
+@JsonInclude(Include.NON_NULL)
+public class Text implements FlexComponent {
+
+    public enum TextWeight {
+        @JsonProperty("regular")
+        Regular,
+        @JsonProperty("bold")
+        Bold,
+    }
+
+    private final Integer flex;
+
+    private final String text;
+
+    private final FxFontSize size;
+
+    private final FxAlign align;
+
+    private final FxGravity gravity;
+
+    private final String color;
+
+    private final TextWeight weight;
+
+    private final Boolean wrap;
+
+    private final FxMarginSize margin;
+
+    private final Action action;
+
+    @JsonCreator
+    public Text(
+            @JsonProperty("flex") Integer flex,
+            @JsonProperty("text") String text,
+            @JsonProperty("size") FxFontSize size,
+            @JsonProperty("align") FxAlign align,
+            @JsonProperty("gravity") FxGravity gravity,
+            @JsonProperty("color") String color,
+            @JsonProperty("weight") TextWeight weight,
+            @JsonProperty("wrap") Boolean wrap,
+            @JsonProperty("margin") FxMarginSize margin,
+            @JsonProperty("action") Action action) {
+        this.flex = flex;
+        this.text = text;
+        this.size = size;
+        this.align = align;
+        this.gravity = gravity;
+        this.color = color;
+        this.weight = weight;
+        this.wrap = wrap;
+        this.margin = margin;
+        this.action = action;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/container/Bubble.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/container/Bubble.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.container;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import com.linecorp.bot.model.message.flex.component.Box;
+import com.linecorp.bot.model.message.flex.component.Image;
+import com.linecorp.bot.model.message.flex.unit.FxDirection;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@JsonTypeName("bubble")
+@JsonInclude(Include.NON_NULL)
+public class Bubble implements FlexContainer {
+
+    private final FxDirection direction;
+
+    private final BubbleStyles styles;
+
+    private final Box header;
+
+    private final Image hero;
+
+    private final Box body;
+
+    private final Box footer;
+
+    @JsonCreator
+    public Bubble(
+            @JsonProperty("direction") FxDirection direction,
+            @JsonProperty("styles") BubbleStyles styles,
+            @JsonProperty("header") Box header,
+            @JsonProperty("hero") Image hero,
+            @JsonProperty("body") Box body,
+            @JsonProperty("footer") Box footer) {
+        this.direction = direction;
+        this.styles = styles;
+        this.header = header;
+        this.hero = hero;
+        this.body = body;
+        this.footer = footer;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/container/BubbleStyles.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/container/BubbleStyles.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.container;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@JsonInclude(Include.NON_NULL)
+public class BubbleStyles {
+
+    @Value
+    @Builder
+    @JsonInclude(Include.NON_NULL)
+    public static class BlockStyle {
+        private final String backgroundColor;
+
+        private final Boolean separator;
+
+        private final String separatorColor;
+
+        @JsonCreator
+        public BlockStyle(
+                @JsonProperty("backgroundColor") String backgroundColor,
+                @JsonProperty("separator") Boolean separator,
+                @JsonProperty("separatorColor") String separatorColor) {
+            this.backgroundColor = backgroundColor;
+            this.separator = separator;
+            this.separatorColor = separatorColor;
+        }
+    }
+
+    private final BlockStyle header;
+
+    private final BlockStyle hero;
+
+    private final BlockStyle body;
+
+    private final BlockStyle footer;
+
+    @JsonCreator
+    public BubbleStyles(
+            @JsonProperty("header") BlockStyle header,
+            @JsonProperty("hero") BlockStyle hero,
+            @JsonProperty("body") BlockStyle body,
+            @JsonProperty("footer") BlockStyle footer) {
+        this.header = header;
+        this.hero = hero;
+        this.body = body;
+        this.footer = footer;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/container/Carousel.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/container/Carousel.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.container;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@JsonTypeName("carousel")
+@JsonInclude(Include.NON_NULL)
+public class Carousel implements FlexContainer {
+
+    private final List<Bubble> contents;
+
+    @JsonCreator
+    public Carousel(@JsonProperty("contents") List<Bubble> contents) {
+        this.contents = contents != null ? contents : Collections.emptyList();
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/container/FlexContainer.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/container/FlexContainer.java
@@ -14,36 +14,20 @@
  * under the License.
  */
 
-package com.linecorp.bot.model.message;
+package com.linecorp.bot.model.message.flex.container;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 
-/**
- * Interface of Message object.
- *
- * <h2>JSON Deserialization</h2>
- *
- * <p>If you want serialize/deserialize of this object, please use Jackson's ObjectMapper with
- *
- * <pre>.registerModule(new <a href="https://github.com/FasterXML/jackson-modules-java8/tree/master/parameter-names">ParameterNamesModule</a>());</pre>
- */
+@JsonSubTypes({
+        @JsonSubTypes.Type(Bubble.class),
+        @JsonSubTypes.Type(Carousel.class)
+})
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
         include = As.PROPERTY,
         property = "type"
 )
-@JsonSubTypes({
-        @JsonSubTypes.Type(TextMessage.class),
-        @JsonSubTypes.Type(ImageMessage.class),
-        @JsonSubTypes.Type(StickerMessage.class),
-        @JsonSubTypes.Type(LocationMessage.class),
-        @JsonSubTypes.Type(AudioMessage.class),
-        @JsonSubTypes.Type(VideoMessage.class),
-        @JsonSubTypes.Type(ImagemapMessage.class),
-        @JsonSubTypes.Type(TemplateMessage.class),
-        @JsonSubTypes.Type(FlexMessage.class),
-})
-public interface Message {
+public interface FlexContainer {
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/unit/FxAlign.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/unit/FxAlign.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.unit;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum FxAlign {
+    @JsonProperty("start")
+    Start,
+    @JsonProperty("end")
+    End,
+    @JsonProperty("center")
+    Center,
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/unit/FxDirection.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/unit/FxDirection.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.unit;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum FxDirection {
+    @JsonProperty("ltr")
+    LTR,
+    @JsonProperty("rtl")
+    RTL
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/unit/FxFontSize.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/unit/FxFontSize.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.unit;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum FxFontSize {
+    @JsonProperty("xxs")
+    XXs,
+    @JsonProperty("xs")
+    Xs,
+    @JsonProperty("sm")
+    Sm,
+    @JsonProperty("md")
+    Md,
+    @JsonProperty("lg")
+    Lg,
+    @JsonProperty("xl")
+    Xl,
+    @JsonProperty("xxl")
+    XXl,
+    @JsonProperty("3xl")
+    XXXl,
+    @JsonProperty("4xl")
+    XXXXl,
+    @JsonProperty("5xl")
+    XXXXXl,
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/unit/FxGravity.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/unit/FxGravity.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.unit;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum FxGravity {
+    @JsonProperty("top")
+    Top,
+    @JsonProperty("bottom")
+    Bottom,
+    @JsonProperty("center")
+    Center,
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/unit/FxLayout.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/unit/FxLayout.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.unit;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum FxLayout {
+    @JsonProperty("horizontal")
+    Horizontal,
+    @JsonProperty("vertical")
+    Vertical,
+    @JsonProperty("baseline")
+    Baseline,
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/unit/FxMarginSize.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/unit/FxMarginSize.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.message.flex.unit;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum FxMarginSize {
+    @JsonProperty("default")
+    Default,
+    @JsonProperty("none")
+    None,
+    @JsonProperty("xs")
+    Xs,
+    @JsonProperty("sm")
+    Sm,
+    @JsonProperty("md")
+    Md,
+    @JsonProperty("lg")
+    Lg,
+    @JsonProperty("xl")
+    Xl,
+    @JsonProperty("xxl")
+    Xxl;
+}

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/message/MessageJsonReconstructionTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/message/MessageJsonReconstructionTest.java
@@ -4,6 +4,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -12,6 +14,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.bot.model.action.MessageAction;
 import com.linecorp.bot.model.action.PostbackAction;
 import com.linecorp.bot.model.action.URIAction;
+import com.linecorp.bot.model.message.flex.component.Box;
+import com.linecorp.bot.model.message.flex.component.Button;
+import com.linecorp.bot.model.message.flex.component.Button.ButtonHeight;
+import com.linecorp.bot.model.message.flex.component.Button.ButtonStyle;
+import com.linecorp.bot.model.message.flex.component.Icon;
+import com.linecorp.bot.model.message.flex.component.Image;
+import com.linecorp.bot.model.message.flex.component.Image.ImageAspectMode;
+import com.linecorp.bot.model.message.flex.component.Image.ImageAspectRatio;
+import com.linecorp.bot.model.message.flex.component.Image.ImageSize;
+import com.linecorp.bot.model.message.flex.component.Text;
+import com.linecorp.bot.model.message.flex.component.Text.TextWeight;
+import com.linecorp.bot.model.message.flex.container.Bubble;
+import com.linecorp.bot.model.message.flex.unit.FxFontSize;
+import com.linecorp.bot.model.message.flex.unit.FxLayout;
+import com.linecorp.bot.model.message.flex.unit.FxMarginSize;
 import com.linecorp.bot.model.message.imagemap.ImagemapBaseSize;
 import com.linecorp.bot.model.message.template.ButtonsTemplate;
 import com.linecorp.bot.model.message.template.CarouselColumn;
@@ -95,6 +112,131 @@ public class MessageJsonReconstructionTest {
                 new ButtonsTemplate("https://example.com", "title", "text",
                                     singletonList(new MessageAction("label", "text")));
         test(new TemplateMessage("ALT", buttonsTemplate));
+    }
+
+    @Test
+    public void flexMessage() {
+        final Image heroBlock =
+                Image.builder()
+                     .url("https://example.com/cafe.jpg")
+                     .size(ImageSize.FullWidth)
+                     .aspectRatio(ImageAspectRatio.R20to13)
+                     .aspectMode(ImageAspectMode.Cover)
+                     .action(new URIAction("label", "http://example.com"))
+                     .build();
+
+        final Box bodyBlock;
+        {
+            final Text title =
+                    Text.builder().text("Brown Cafe").weight(TextWeight.Bold).size(FxFontSize.Xl).build();
+
+            final Box review;
+            {
+                final Icon goldStar =
+                        Icon.builder().size(FxFontSize.Sm).url("https://example.com/gold_star.png").build();
+                final Icon grayStar =
+                        Icon.builder().size(FxFontSize.Sm).url("https://example.com/gray_star.png").build();
+                final Text point =
+                        Text.builder()
+                            .text("4.0")
+                            .size(FxFontSize.Sm)
+                            .color("#999999")
+                            .margin(FxMarginSize.Md)
+                            .flex(0)
+                            .build();
+
+                review = Box.builder()
+                            .layout(FxLayout.Baseline)
+                            .margin(FxMarginSize.Md)
+                            .contents(Arrays.asList(goldStar, goldStar, goldStar, goldStar, grayStar, point))
+                            .build();
+            }
+
+            final Box info;
+            {
+                final Box place =
+                        Box.builder()
+                           .layout(FxLayout.Baseline)
+                           .spacing(FxMarginSize.Sm)
+                           .contents(
+                                   Arrays.asList(
+                                           Text.builder()
+                                               .text("Place")
+                                               .color("#aaaaaa")
+                                               .size(FxFontSize.Sm)
+                                               .flex(1)
+                                               .build(),
+                                           Text.builder()
+                                               .text("Shinjuku, Tokyo")
+                                               .wrap(true)
+                                               .color("#666666")
+                                               .size(FxFontSize.Sm)
+                                               .flex(5)
+                                               .build()
+                                   )
+                           )
+                           .build();
+                final Box time =
+                        Box.builder()
+                           .layout(FxLayout.Baseline)
+                           .spacing(FxMarginSize.Sm)
+                           .contents(
+                                   Arrays.asList(
+                                           Text.builder()
+                                               .text("Time")
+                                               .color("#aaaaaa")
+                                               .size(FxFontSize.Sm)
+                                               .flex(1)
+                                               .build(),
+                                           Text.builder()
+                                               .text("10:00 - 23:00")
+                                               .wrap(true)
+                                               .color("#666666")
+                                               .size(FxFontSize.Sm)
+                                               .flex(5)
+                                               .build()
+                                   )
+                           )
+                           .build();
+
+                info = Box.builder()
+                          .layout(FxLayout.Vertical)
+                          .margin(FxMarginSize.Lg)
+                          .spacing(FxMarginSize.Sm)
+                          .contents(Arrays.asList(place, time))
+                          .build();
+            }
+
+            bodyBlock = Box.builder()
+                      .layout(FxLayout.Vertical)
+                      .contents(Arrays.asList(title, review, info))
+                      .build();
+        }
+
+        final Box footerBlock;
+        {
+            final Button callAction =
+                    Button.builder()
+                          .style(ButtonStyle.Link)
+                          .height(ButtonHeight.Small)
+                          .action(new URIAction("CALL", "tell:000000"))
+                          .build();
+            final Button websiteAction =
+                    Button.builder()
+                          .style(ButtonStyle.Link)
+                          .height(ButtonHeight.Small)
+                          .action(new URIAction("WEBSITE", "http://example.com"))
+                          .build();
+
+            footerBlock = Box.builder()
+                        .layout(FxLayout.Vertical)
+                        .spacing(FxMarginSize.Sm)
+                        .contents(Arrays.asList(callAction, websiteAction))
+                        .build();
+        }
+
+        final Bubble bubble = Bubble.builder().hero(heroBlock).body(bodyBlock).footer(footerBlock).build();
+        test(new FlexMessage("ALT", bubble));
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR enables us to easily construct a flex message instance.

# Background

Flex message is released
https://linecorp.com/ja/pr/news/ja/2018/2231

# Changes

* flex's JSON schema model classes are added

### Package structure

#### com.linecorp.bot.model.message
`FlexMessage` is added

#### com.linecorp.bot.model.message.flex.component
flex's `component` models (`box`, `button`, `image`, etc) are added

#### com.linecorp.bot.model.message.flex.container
flex's `container` models (`bubble`, `carousel`) are added

#### com.linecorp.bot.model.message.flex.unit
flex's enum definitions are added
