### PR TITLE
fixup: project build from root directory issue.

### DIFF
--- a/line-bot-cli/build.gradle
+++ b/line-bot-cli/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'org.springframework.boot'
 
 bootRepackage {
     executable = true
-    embeddedLaunchScript = new File('src/main/resources/launch.script')
+    embeddedLaunchScript = file('src/main/resources/launch.script')
     // Custom Launch Script avoid https://github.com/spring-projects/spring-boot/issues/5164
 }
 


### PR DESCRIPTION
This issue closes https://github.com/line/line-bot-sdk-java/issues/207

`new File()` based from current directory. Not project root.