### PR TITLE
Make LineMessagingService package-private.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,7 +159,7 @@ subprojects {
     }
 
     compileJava {
-        options.compilerArgs << '-Xlint:all' << '-Werror' << '-Xlint:-processing' << '-parameters'
+        options.compilerArgs << '-Xlint:all' << '-Xlint:deprecation' << '-Werror' << '-Xlint:-processing' << '-parameters'
     }
 
     project.plugins.withType(org.springframework.boot.gradle.plugin.SpringBootPlugin) {

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClientBuilder.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClientBuilder.java
@@ -6,6 +6,11 @@ import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
 
 public class LineMessagingClientBuilder {
+    public static final String DEFAULT_API_END_POINT = "https://api.line.me/";
+    public static final long DEFAULT_CONNECT_TIMEOUT = 10_000;
+    public static final long DEFAULT_READ_TIMEOUT = 10_000;
+    public static final long DEFAULT_WRITE_TIMEOUT = 10_000;
+
     //TODO: Move into all builder logic into this class from LineMessagingClientBuilder.
     private final LineMessagingServiceBuilder delegate;
 

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClientImpl.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClientImpl.java
@@ -46,7 +46,7 @@ import retrofit2.Response;
  * Proxy implementation of {@link LineMessagingClient} to hind internal implementation.
  */
 @Slf4j
-@AllArgsConstructor(onConstructor = @__(@SuppressWarnings("deprecation")))
+@AllArgsConstructor
 public class LineMessagingClientImpl implements LineMessagingClient {
     private static final ExceptionConverter EXCEPTION_CONVERTER = new ExceptionConverter();
     private static final String ORG_TYPE_GROUP = "group"; // TODO Enum
@@ -55,7 +55,6 @@ public class LineMessagingClientImpl implements LineMessagingClient {
     private static final Function<Void, BotApiResponse>
             VOID_TO_BOT_API_SUCCESS_RESPONSE = ignored -> BOT_API_SUCCESS_RESPONSE;
 
-    @SuppressWarnings("deprecation")
     private final LineMessagingService retrofitImpl;
 
     @Override

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingService.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingService.java
@@ -39,10 +39,10 @@ import retrofit2.http.Query;
 import retrofit2.http.Streaming;
 
 /**
- * @deprecated Please use {@link LineMessagingClient} instead.
+ * Since 2018-06. This class is package private. Please use {@link LineMessagingClient} instead.
+ * It's implementation free.
  */
-@Deprecated
-public interface LineMessagingService {
+interface LineMessagingService {
     /**
      * Reply to messages from users.
      *
@@ -74,6 +74,7 @@ public interface LineMessagingService {
      * <p>INFO: Only available for plans which support push messages. Messages cannot be sent to groups or rooms.
      * <p>INFO: Use IDs returned via the webhook event of source users. IDs of groups or rooms cannot be used.
      * Do not use the LINE ID found on the LINE app.</p>
+     *
      * @see #pushMessage(PushMessage)
      * @see <a href="https://devdocs.line.me?java#multicast">//devdocs.line.me#multicast</a>
      */

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingServiceBuilder.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingServiceBuilder.java
@@ -36,16 +36,11 @@ import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
-public class LineMessagingServiceBuilder {
-    public static final String DEFAULT_API_END_POINT = "https://api.line.me/";
-    public static final long DEFAULT_CONNECT_TIMEOUT = 10_000;
-    public static final long DEFAULT_READ_TIMEOUT = 10_000;
-    public static final long DEFAULT_WRITE_TIMEOUT = 10_000;
-
-    private String apiEndPoint = DEFAULT_API_END_POINT;
-    private long connectTimeout = DEFAULT_CONNECT_TIMEOUT;
-    private long readTimeout = DEFAULT_READ_TIMEOUT;
-    private long writeTimeout = DEFAULT_WRITE_TIMEOUT;
+class LineMessagingServiceBuilder {
+    private String apiEndPoint = LineMessagingClientBuilder.DEFAULT_API_END_POINT;
+    private long connectTimeout = LineMessagingClientBuilder.DEFAULT_CONNECT_TIMEOUT;
+    private long readTimeout = LineMessagingClientBuilder.DEFAULT_READ_TIMEOUT;
+    private long writeTimeout = LineMessagingClientBuilder.DEFAULT_WRITE_TIMEOUT;
     private List<Interceptor> interceptors = new ArrayList<>();
 
     private OkHttpClient.Builder okHttpClientBuilder;
@@ -165,8 +160,7 @@ public class LineMessagingServiceBuilder {
     /**
      * Creates a new {@link LineMessagingService}.
      */
-    @SuppressWarnings("deprecation")
-    public LineMessagingService build() {
+    LineMessagingService build() {
         if (okHttpClientBuilder == null) {
             okHttpClientBuilder = new OkHttpClient.Builder();
         }

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotAutoConfiguration.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotAutoConfiguration.java
@@ -28,8 +28,6 @@ import com.linecorp.bot.client.ChannelManagementSyncClient;
 import com.linecorp.bot.client.ChannelTokenSupplier;
 import com.linecorp.bot.client.FixedChannelTokenSupplier;
 import com.linecorp.bot.client.LineMessagingClient;
-import com.linecorp.bot.client.LineMessagingClientImpl;
-import com.linecorp.bot.client.LineMessagingServiceBuilder;
 import com.linecorp.bot.spring.boot.support.LineMessageHandlerSupport;
 
 /**
@@ -44,19 +42,6 @@ public class LineBotAutoConfiguration {
     private LineBotProperties lineBotProperties;
 
     @Bean
-    @SuppressWarnings("deprecation")
-    public com.linecorp.bot.client.LineMessagingService lineMessagingService(
-            final ChannelTokenSupplier channelTokenSupplier) {
-        return LineMessagingServiceBuilder
-                .create(channelTokenSupplier)
-                .apiEndPoint(lineBotProperties.getApiEndPoint())
-                .connectTimeout(lineBotProperties.getConnectTimeout())
-                .readTimeout(lineBotProperties.getReadTimeout())
-                .writeTimeout(lineBotProperties.getWriteTimeout())
-                .build();
-    }
-
-    @Bean
     @ConditionalOnMissingBean(ChannelTokenSupplier.class)
     public ChannelTokenSupplier channelTokenSupplier() {
         final String channelToken = lineBotProperties.getChannelToken();
@@ -65,9 +50,14 @@ public class LineBotAutoConfiguration {
 
     @Bean
     public LineMessagingClient lineMessagingClient(
-            @SuppressWarnings("deprecation")
-            final com.linecorp.bot.client.LineMessagingService lineMessagingService) {
-        return new LineMessagingClientImpl(lineMessagingService);
+            final ChannelTokenSupplier channelTokenSupplier) {
+        return LineMessagingClient
+                .builder(channelTokenSupplier)
+                .apiEndPoint(lineBotProperties.getApiEndPoint())
+                .connectTimeout(lineBotProperties.getConnectTimeout())
+                .readTimeout(lineBotProperties.getReadTimeout())
+                .writeTimeout(lineBotProperties.getWriteTimeout())
+                .build();
     }
 
     @Bean

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotProperties.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotProperties.java
@@ -24,7 +24,7 @@ import javax.validation.constraints.NotNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
-import com.linecorp.bot.client.LineMessagingServiceBuilder;
+import com.linecorp.bot.client.LineMessagingClientBuilder;
 import com.linecorp.bot.spring.boot.BotPropertiesValidator.ValidBotProperties;
 import com.linecorp.bot.spring.boot.annotation.EventMapping;
 import com.linecorp.bot.spring.boot.annotation.LineMessageHandler;
@@ -59,28 +59,28 @@ public class LineBotProperties {
 
     @Valid
     @NotNull
-    private String apiEndPoint = LineMessagingServiceBuilder.DEFAULT_API_END_POINT;
+    private String apiEndPoint = LineMessagingClientBuilder.DEFAULT_API_END_POINT;
 
     /**
      * Connection timeout in milliseconds
      */
     @Valid
     @NotNull
-    private long connectTimeout = LineMessagingServiceBuilder.DEFAULT_CONNECT_TIMEOUT;
+    private long connectTimeout = LineMessagingClientBuilder.DEFAULT_CONNECT_TIMEOUT;
 
     /**
      * Read timeout in milliseconds
      */
     @Valid
     @NotNull
-    private long readTimeout = LineMessagingServiceBuilder.DEFAULT_READ_TIMEOUT;
+    private long readTimeout = LineMessagingClientBuilder.DEFAULT_READ_TIMEOUT;
 
     /**
      * Write timeout in milliseconds
      */
     @Valid
     @NotNull
-    private long writeTimeout = LineMessagingServiceBuilder.DEFAULT_WRITE_TIMEOUT;
+    private long writeTimeout = LineMessagingClientBuilder.DEFAULT_WRITE_TIMEOUT;
 
     /**
      * Configuration for {@link LineMessageHandler} and {@link EventMapping}.


### PR DESCRIPTION
Now LineMessagingService which uses Rertofit's Call is SDK internal class.
Use LineMessagingClient and it's builder() instead.

This also fixed following compiler warnings.

```
> Task :line-bot-api-client:compileTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
```

This relates https://github.com/line/line-bot-sdk-java/pull/113.