### PR TITLE
Remove non-used stub.

### DIFF
--- a/line-bot-servlet/src/test/java/com/linecorp/bot/servlet/LineBotCallbackRequestParserTest.java
+++ b/line-bot-servlet/src/test/java/com/linecorp/bot/servlet/LineBotCallbackRequestParserTest.java
@@ -19,8 +19,6 @@ package com.linecorp.bot.servlet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,7 +34,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -51,9 +48,6 @@ import com.linecorp.bot.model.event.message.TextMessageContent;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LineBotCallbackRequestParserTest {
-    @Mock
-    private HttpServletResponse response;
-
     @Spy
     private LineSignatureValidator lineSignatureValidator = new LineSignatureValidator(
             "SECRET".getBytes(StandardCharsets.UTF_8));
@@ -65,8 +59,6 @@ public class LineBotCallbackRequestParserTest {
 
     @Before
     public void before() throws IOException {
-        when(response.getWriter())
-                .thenReturn(mock(PrintWriter.class));
         this.lineBotCallbackRequestParser = new LineBotCallbackRequestParser(lineSignatureValidator);
     }
 


### PR DESCRIPTION
Remove following exception in future mockito version.
```
org.mockito.exceptions.misusing.UnnecessaryStubbingException:
Unnecessary stubbings detected in test class: LineBotCallbackRequestParserTest
Clean & maintainable test code requires zero unnecessary code.
Following stubbings are unnecessary (click to navigate to relevant line of code):
  1. -> at com.linecorp.bot.servlet.LineBotCallbackRequestParserTest.before(LineBotCallbackRequestParserTest.java:68)
Please remove unnecessary stubbings or use 'lenient' strictness. More info: javadoc for UnnecessaryStubbingException class.
```

This is needed by https://github.com/line/line-bot-sdk-java/pull/222.