### PR TITLE
NON-ISSUE: Update deprecated gradle feature.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,8 +99,8 @@ subprojects {
     }
 
     dependencies {
-        compileOnly 'org.projectlombok:lombok'
-        testCompileOnly 'org.projectlombok:lombok'
+        annotationProcessor 'org.projectlombok:lombok'
+        testAnnotationProcessor 'org.projectlombok:lombok'
 
         compileOnly "org.springframework.boot:spring-boot-configuration-processor"
         // http://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html#configuration-metadata-annotation-processor

--- a/test-boot2-compatibility/build.gradle
+++ b/test-boot2-compatibility/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
 test {
     setTestClassesDirs(files(
-        project.sourceSets.test.output.classesDir, // Default
+        project.sourceSets.test.java.outputDir, // Default
         project(':line-bot-model').sourceSets.test.output,
         project(':line-bot-api-client').sourceSets.test.output,
         project(':line-bot-servlet').sourceSets.test.output,


### PR DESCRIPTION
This PR fixes following issue.

Example: https://travis-ci.org/line/line-bot-sdk-java/builds/406063517#L1068-L1069
> Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
> See https://docs.gradle.org/4.8/userguide/command_line_interface.html#sec:command_line_warnings

```
> Configure project :test-boot2-compatibility
Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set. This behaviour has been deprecated and is scheduled to be removed in Gradle 5.0

> Task :line-bot-model:compileJava
The following annotation processors were detected on the compile classpath: 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor' and 'lombok.launch.AnnotationProcessorHider$ClaimingProcessor' and 'org.springframework.boot.configurationprocessor.ConfigurationMetadataAnnotationProcessor'. Detecting annotation processors on the compile classpath is deprecated and Gradle 5.0 will ignore them. Please add them to the annotation processor path instead. If you did not intend to use annotation processors, you can use the '-proc:none' compiler argument to ignore them.

> Task :line-bot-model:compileTestJava
The following annotation processors were detected on the compile classpath: 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor' and 'lombok.launch.AnnotationProcessorHider$ClaimingProcessor'. Detecting annotation processors on the compile classpath is deprecated and Gradle 5.0 will ignore them. Please add them to the annotation processor path instead. If you did not intend to use annotation processors, you can use the '-proc:none' compiler argument to ignore them.
```