### PR TITLE
Revert "Update copyright year."

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The line-bot-spring-boot module lets you build a bot application as a Spring Boo
 
 ```java
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -25,7 +25,7 @@
 
   <!-- Copyright headers -->
   <module name="RegexpSingleline">
-    <property name="format" value="^ \* Copyright 2018 LINE Corporation$" />
+    <property name="format" value="^ \* Copyright \d{4} LINE Corporation$" />
     <property name="minimum" value="1" />
     <property name="maximum" value="1" />
     <property name="message" value="missing copyright header" />

--- a/line-bot-api-client/build.gradle
+++ b/line-bot-api-client/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/ChannelTokenSupplier.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/ChannelTokenSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/ExceptionConverter.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/ExceptionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/FixedChannelTokenSupplier.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/FixedChannelTokenSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/HeaderInterceptor.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/HeaderInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClient.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClientImpl.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingService.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingServiceBuilder.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingServiceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineSignatureValidator.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineSignatureValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/MessageContentResponse.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/MessageContentResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/BadRequestException.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/BadRequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/ForbiddenException.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/ForbiddenException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/GeneralLineMessagingException.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/GeneralLineMessagingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/LineMessagingException.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/LineMessagingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/LineServerException.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/LineServerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/TooManyRequestsException.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/TooManyRequestsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/UnauthorizedException.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/exception/UnauthorizedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/AbstractWiremockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/AbstractWiremockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/CallbackAdaptorTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/CallbackAdaptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/ExceptionConverterTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/ExceptionConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/FixedChannelTokenSupplierTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/FixedChannelTokenSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/HeaderInterceptorWireMockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/HeaderInterceptorWireMockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplWiremockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplWiremockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingServiceTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineSignatureValidatorTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineSignatureValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/ResponseBodyCallbackAdaptorTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/ResponseBodyCallbackAdaptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/build.gradle
+++ b/line-bot-model/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/PushMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/PushMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/ReplyMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/ReplyMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/action/Action.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/action/Action.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/action/DatetimePickerAction.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/action/DatetimePickerAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/action/MessageAction.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/action/MessageAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/action/PostbackAction.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/action/PostbackAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/action/URIAction.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/action/URIAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/error/ErrorDetail.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/error/ErrorDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/error/ErrorResponse.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/error/ErrorResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/BeaconEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/BeaconEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/CallbackRequest.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/CallbackRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/Event.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/FollowEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/FollowEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/JoinEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/JoinEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/LeaveEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/LeaveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/MessageEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/MessageEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/PostbackEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/PostbackEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/UnfollowEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/UnfollowEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/UnknownEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/UnknownEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/beacon/BeaconContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/beacon/BeaconContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/beacon/BeaconContentUtil.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/beacon/BeaconContentUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2017 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/AudioMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/AudioMessageContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/FileMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/FileMessageContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/ImageMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/ImageMessageContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/LocationMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/LocationMessageContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/MessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/MessageContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/StickerMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/StickerMessageContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/TextMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/TextMessageContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/UnknownMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/UnknownMessageContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/VideoMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/VideoMessageContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/postback/PostbackContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/postback/PostbackContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/GroupSource.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/GroupSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/RoomSource.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/RoomSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/Source.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/Source.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/UnknownSource.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/UnknownSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/UserSource.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/UserSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/AudioMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/AudioMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/ImageMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/ImageMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/ImagemapMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/ImagemapMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/LocationMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/LocationMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/Message.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/StickerMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/StickerMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/TemplateMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/TemplateMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/TextMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/TextMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/VideoMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/VideoMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/imagemap/ImagemapAction.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/imagemap/ImagemapAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/imagemap/ImagemapArea.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/imagemap/ImagemapArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/imagemap/ImagemapBaseSize.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/imagemap/ImagemapBaseSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/imagemap/MessageImagemapAction.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/imagemap/MessageImagemapAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/imagemap/URIImagemapAction.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/imagemap/URIImagemapAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/ButtonsTemplate.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/ButtonsTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/CarouselColumn.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/CarouselColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/CarouselTemplate.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/CarouselTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/ConfirmTemplate.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/ConfirmTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/ImageCarouselColumn.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/ImageCarouselColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/ImageCarouselTemplate.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/ImageCarouselTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/Template.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/template/Template.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/profile/UserProfileResponse.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/profile/UserProfileResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/response/BotApiResponse.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/response/BotApiResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/error/ErrorResponseTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/error/ErrorResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/event/MessageEventTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/event/MessageEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/event/beacon/BeaconContentTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/event/beacon/BeaconContentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2017 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/event/beacon/BeaconContentUtilTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/event/beacon/BeaconContentUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2017 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/message/ImagemapMessageTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/message/ImagemapMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/message/imagemap/MessageImagemapActionTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/message/imagemap/MessageImagemapActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/message/imagemap/URIImagemapActionTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/message/imagemap/URIImagemapActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/profile/ProfileResponseTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/profile/ProfileResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-servlet/build.gradle
+++ b/line-bot-servlet/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-servlet/src/main/java/com/linecorp/bot/servlet/LineBotCallbackException.java
+++ b/line-bot-servlet/src/main/java/com/linecorp/bot/servlet/LineBotCallbackException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-servlet/src/main/java/com/linecorp/bot/servlet/LineBotCallbackRequestParser.java
+++ b/line-bot-servlet/src/main/java/com/linecorp/bot/servlet/LineBotCallbackRequestParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-servlet/src/test/java/com/linecorp/bot/servlet/LineBotCallbackRequestParserTest.java
+++ b/line-bot-servlet/src/test/java/com/linecorp/bot/servlet/LineBotCallbackRequestParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-spring-boot/build.gradle
+++ b/line-bot-spring-boot/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/BotPropertiesValidator.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/BotPropertiesValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotAutoConfiguration.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotProperties.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotWebMvcConfigurer.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/LineBotWebMvcConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/annotation/EnableLineMessaging.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/annotation/EnableLineMessaging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/annotation/EventMapping.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/annotation/EventMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/annotation/LineBotMessages.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/annotation/LineBotMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/annotation/LineMessageHandler.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/annotation/LineMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/interceptor/LineBotServerInterceptor.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/interceptor/LineBotServerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineBotServerArgumentProcessor.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineBotServerArgumentProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupport.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/BotPropertiesValidatorTest.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/BotPropertiesValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/IntegrationTest.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/IntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupportTest.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/sample-spring-boot-echo/build.gradle
+++ b/sample-spring-boot-echo/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/sample-spring-boot-echo/src/main/java/com/example/bot/spring/echo/EchoApplication.java
+++ b/sample-spring-boot-echo/src/main/java/com/example/bot/spring/echo/EchoApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/sample-spring-boot-echo/src/main/resources/application-template.yml
+++ b/sample-spring-boot-echo/src/main/resources/application-template.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 LINE Corporation
+# Copyright 2016 LINE Corporation
 #
 # LINE Corporation licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/sample-spring-boot-kitchensink/build.gradle
+++ b/sample-spring-boot-kitchensink/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/KitchenSinkApplication.java
+++ b/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/KitchenSinkApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/KitchenSinkController.java
+++ b/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/KitchenSinkController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/KitchenSinkWebMvcConfigurer.java
+++ b/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/KitchenSinkWebMvcConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/sample-spring-boot-kitchensink/src/main/resources/application-template.yml
+++ b/sample-spring-boot-kitchensink/src/main/resources/application-template.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 LINE Corporation
+# Copyright 2016 LINE Corporation
 #
 # LINE Corporation licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ include 'line-bot-cli'
 include 'test-boot2-compatibility'
 
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2016 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance


### PR DESCRIPTION
Reverts line/line-bot-sdk-java#175

Sorry, according to advices for copyright professionals, should not update copyright header from first published for each source code file.