### PR TITLE
Use builder style in model/event class to make adding field more easyly and safely.

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/AccountLinkEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/AccountLinkEvent.java
@@ -18,7 +18,6 @@ package com.linecorp.bot.model.event;
 
 import java.time.Instant;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -35,12 +34,18 @@ import lombok.Value;
  * Event object for when a user has linked his/her LINE account with a provider's service account.
  * You can reply to account link events.
  */
-@Value
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonTypeName("accountLink")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE, onConstructor = @__(@Deprecated))
+// TODO: Remove next release. Use builder() instead.
 @JsonDeserialize(builder = AccountLinkEvent.AccountLinkEventBuilder.class)
 public class AccountLinkEvent implements Event, ReplyEvent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class AccountLinkEventBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     /**
      * Token for replying to this event.
      */
@@ -81,15 +86,10 @@ public class AccountLinkEvent implements Event, ReplyEvent {
      */
     @Deprecated
     public AccountLinkEvent(
-            @JsonProperty("replyToken") String replyToken,
-            @JsonProperty("source") Source source,
-            @JsonProperty("timestamp") Instant timestamp,
-            @JsonProperty("link") LinkContent link) {
+            String replyToken,
+            Source source,
+            Instant timestamp,
+            LinkContent link) {
         this(replyToken, source, timestamp, link, null);
-    }
-
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class AccountLinkEventBuilder {
-        // Filled by lombok
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/BeaconEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/BeaconEvent.java
@@ -18,7 +18,6 @@ package com.linecorp.bot.model.event;
 
 import java.time.Instant;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -34,12 +33,18 @@ import lombok.Value;
 /**
  * Event object for when a user detects a LINE Beacon. You can reply to beacon events.
  */
-@Value
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonTypeName("beacon")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE, onConstructor = @__(@Deprecated))
+// TODO: Remove next release. Use builder() instead.
 @JsonDeserialize(builder = BeaconEvent.BeaconEventBuilder.class)
 public class BeaconEvent implements Event, ReplyEvent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class BeaconEventBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     /**
      * Token for replying to this event.
      */
@@ -80,15 +85,10 @@ public class BeaconEvent implements Event, ReplyEvent {
      */
     @Deprecated
     public BeaconEvent(
-            @JsonProperty("replyToken") final String replyToken,
-            @JsonProperty("source") final Source source,
-            @JsonProperty("timestamp") final Instant timestamp,
-            @JsonProperty("beacon") final BeaconContent beacon) {
+            final String replyToken,
+            final Source source,
+            final Instant timestamp,
+            final BeaconContent beacon) {
         this(replyToken, source, beacon, timestamp, null);
-    }
-
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class BeaconEventBuilder {
-        // Filled by lombok
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/CallbackRequest.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/CallbackRequest.java
@@ -18,16 +18,26 @@ package com.linecorp.bot.model.event;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 /**
  * Request object for webhook.
  */
 @Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = CallbackRequest.CallbackRequestBuilder.class)
 public class CallbackRequest {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class CallbackRequestBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     /**
      * A user ID of a bot that should receive webhook events. The user ID value is
      * a string that matches the regular expression, {@code U[0-9a-f]{32}}.
@@ -38,11 +48,4 @@ public class CallbackRequest {
      * List of events.
      */
     List<Event> events;
-
-    @JsonCreator
-    public CallbackRequest(@JsonProperty("events") final List<Event> events,
-                           @JsonProperty("destination") final String destination) {
-        this.events = events;
-        this.destination = destination;
-    }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/FollowEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/FollowEvent.java
@@ -18,7 +18,6 @@ package com.linecorp.bot.model.event;
 
 import java.time.Instant;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -33,12 +32,18 @@ import lombok.Value;
 /**
  * Event object for when your account is added as a friend (or unblocked). You can reply to follow events.
  */
-@Value
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonTypeName("follow")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE, onConstructor = @__(@Deprecated))
+// TODO: Remove next release. Use builder() instead.
 @JsonDeserialize(builder = FollowEvent.FollowEventBuilder.class)
 public class FollowEvent implements Event, ReplyEvent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class FollowEventBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     /**
      * Token for replying to this event.
      */
@@ -74,14 +79,9 @@ public class FollowEvent implements Event, ReplyEvent {
      */
     @Deprecated
     public FollowEvent(
-            @JsonProperty("replyToken") final String replyToken,
-            @JsonProperty("source") final Source source,
-            @JsonProperty("timestamp") final Instant timestamp) {
+            final String replyToken,
+            final Source source,
+            final Instant timestamp) {
         this(replyToken, source, timestamp, null);
-    }
-
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class FollowEventBuilder {
-        // Filled by lombok
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/JoinEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/JoinEvent.java
@@ -18,7 +18,6 @@ package com.linecorp.bot.model.event;
 
 import java.time.Instant;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -33,12 +32,18 @@ import lombok.Value;
 /**
  * Event object for when your account joins a group or talk room. You can reply to join events.
  */
-@Value
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonTypeName("join")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE, onConstructor = @__(@Deprecated))
+// TODO: Remove next release. Use builder() instead.
 @JsonDeserialize(builder = JoinEvent.JoinEventBuilder.class)
 public class JoinEvent implements Event, ReplyEvent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class JoinEventBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     /**
      * Token for replying to this event.
      */
@@ -74,14 +79,9 @@ public class JoinEvent implements Event, ReplyEvent {
      */
     @Deprecated
     public JoinEvent(
-            @JsonProperty("replyToken") final String replyToken,
-            @JsonProperty("source") final Source source,
-            @JsonProperty("timestamp") final Instant timestamp) {
+            final String replyToken,
+            final Source source,
+            final Instant timestamp) {
         this(replyToken, source, timestamp, null);
-    }
-
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class JoinEventBuilder {
-        // Filled by lombok
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/LeaveEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/LeaveEvent.java
@@ -18,7 +18,6 @@ package com.linecorp.bot.model.event;
 
 import java.time.Instant;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -33,12 +32,18 @@ import lombok.Value;
 /**
  * Event object for when your account leaves a group.
  */
-@Value
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonTypeName("leave")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE, onConstructor = @__(@Deprecated))
+// TODO: Remove next release. Use builder() instead.
 @JsonDeserialize(builder = LeaveEvent.LeaveEventBuilder.class)
 public class LeaveEvent implements Event {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class LeaveEventBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     /**
      * JSON object which contains the source of the event.
      */
@@ -69,13 +74,8 @@ public class LeaveEvent implements Event {
      */
     @Deprecated
     public LeaveEvent(
-            @JsonProperty("source") final Source source,
-            @JsonProperty("timestamp") final Instant timestamp) {
+            final Source source,
+            final Instant timestamp) {
         this(source, timestamp, null);
-    }
-
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class LeaveEventBuilder {
-        // Filled by lombok
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/MemberJoinedEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/MemberJoinedEvent.java
@@ -19,8 +19,6 @@ package com.linecorp.bot.model.event;
 import java.time.Instant;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -35,12 +33,18 @@ import lombok.Value;
 /**
  * Event object for when a user joins a group or room that the bot is in.
  */
-@Value
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonTypeName("memberJoined")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE, onConstructor = @__(@Deprecated))
+// TODO: Remove next release. Use builder() instead.
 @JsonDeserialize(builder = MemberJoinedEvent.MemberJoinedEventBuilder.class)
 public class MemberJoinedEvent implements Event, ReplyEvent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class MemberJoinedEventBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     /**
      * Token for replying to this event.
      */
@@ -81,26 +85,25 @@ public class MemberJoinedEvent implements Event, ReplyEvent {
      */
     @Deprecated
     public MemberJoinedEvent(
-            @JsonProperty("replyToken") final String replyToken,
-            @JsonProperty("source") final Source source,
-            @JsonProperty("joined") final JoinedMembers joined,
-            @JsonProperty("timestamp") final Instant timestamp) {
+            final String replyToken,
+            final Source source,
+            final JoinedMembers joined,
+            final Instant timestamp) {
         this(replyToken, source, timestamp, joined, null);
     }
 
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class MemberJoinedEventBuilder {
-        // Filled by lombok
-    }
-
     @Value
+    @Builder(toBuilder = true)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE, onConstructor = @__(@Deprecated))
+    // TODO: Remove next release. Use builder() instead.
+    @JsonDeserialize(builder = JoinedMembers.JoinedMembersBuilder.class)
     public static class JoinedMembers {
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class JoinedMembersBuilder {
+            // Providing builder instead of public constructor. Class body is filled by lombok.
+        }
+
         // User ID of users who joined
         List<Source> members;
-
-        @JsonCreator
-        public JoinedMembers(@JsonProperty("members") List<Source> members) {
-            this.members = members;
-        }
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/MemberLeftEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/MemberLeftEvent.java
@@ -19,8 +19,6 @@ package com.linecorp.bot.model.event;
 import java.time.Instant;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -32,12 +30,18 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
 
-@Value
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonTypeName("memberLeft")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE, onConstructor = @__(@Deprecated))
+// TODO: Remove next release. Use builder() instead.
 @JsonDeserialize(builder = MemberLeftEvent.MemberLeftEventBuilder.class)
 public class MemberLeftEvent implements Event {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class MemberLeftEventBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     /**
      * JSON object which contains the source of the event.
      */
@@ -73,25 +77,24 @@ public class MemberLeftEvent implements Event {
      */
     @Deprecated
     public MemberLeftEvent(
-            @JsonProperty("source") final Source source,
-            @JsonProperty("left") final LeftMembers left,
-            @JsonProperty("timestamp") final Instant timestamp) {
+            final Source source,
+            final LeftMembers left,
+            final Instant timestamp) {
         this(source, timestamp, left, null);
     }
 
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class MemberLeftEventBuilder {
-        // Filled by lombok
-    }
-
     @Value
+    @Builder(toBuilder = true)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE, onConstructor = @__(@Deprecated))
+    // TODO: Remove next release. Use builder() instead.
+    @JsonDeserialize(builder = LeftMembers.LeftMembersBuilder.class)
     public static class LeftMembers {
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class LeftMembersBuilder {
+            // Providing builder instead of public constructor. Class body is filled by lombok.
+        }
+
         // User ID of users who joined
         List<Source> members;
-
-        @JsonCreator
-        public LeftMembers(@JsonProperty("members") List<Source> members) {
-            this.members = members;
-        }
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/MessageEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/MessageEvent.java
@@ -18,7 +18,6 @@ package com.linecorp.bot.model.event;
 
 import java.time.Instant;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -36,12 +35,18 @@ import lombok.Value;
  * The message field contains a message object which corresponds with the message type.
  * You can reply to message events.
  */
-@Value
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonTypeName("message")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE, onConstructor = @__(@Deprecated))
+// TODO: Remove next release. Use builder() instead.
 @JsonDeserialize(builder = MessageEvent.MessageEventBuilder.class)
 public class MessageEvent<T extends MessageContent> implements Event, ReplyEvent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class MessageEventBuilder<T extends MessageContent> {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     /**
      * Token for replying to this event.
      */
@@ -82,15 +87,10 @@ public class MessageEvent<T extends MessageContent> implements Event, ReplyEvent
      */
     @Deprecated
     public MessageEvent(
-            @JsonProperty("replyToken") final String replyToken,
-            @JsonProperty("source") final Source source,
-            @JsonProperty("message") final T message,
-            @JsonProperty("timestamp") final Instant timestamp) {
+            final String replyToken,
+            final Source source,
+            final T message,
+            final Instant timestamp) {
         this(replyToken, source, message, timestamp, null);
-    }
-
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class MessageEventBuilder<T extends MessageContent> {
-        // Filled by lombok
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/PostbackEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/PostbackEvent.java
@@ -35,12 +35,18 @@ import lombok.Value;
  * Event object for when a user performs an action on a template message which initiates a postback.
  * You can reply to postback events.
  */
-@Value
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonTypeName("postback")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE, onConstructor = @__(@Deprecated))
+// TODO: Remove next release. Use builder() instead.
 @JsonDeserialize(builder = PostbackEvent.PostbackEventBuilder.class)
 public class PostbackEvent implements Event, ReplyEvent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class PostbackEventBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     /**
      * Token for replying to this event.
      */
@@ -82,15 +88,10 @@ public class PostbackEvent implements Event, ReplyEvent {
      */
     @Deprecated
     public PostbackEvent(
-            @JsonProperty("replyToken") final String replyToken,
-            @JsonProperty("source") final Source source,
-            @JsonProperty("postback") final PostbackContent postbackContent,
-            @JsonProperty("timestamp") final Instant timestamp) {
+            final String replyToken,
+            final Source source,
+            final PostbackContent postbackContent,
+            final Instant timestamp) {
         this(replyToken, source, postbackContent, timestamp, null);
-    }
-
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class PostbackEventBuilder {
-        // Filled by lombok
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/ThingsEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/ThingsEvent.java
@@ -18,7 +18,6 @@ package com.linecorp.bot.model.event;
 
 import java.time.Instant;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -34,12 +33,18 @@ import lombok.Value;
 /**
  * Event object for when a user detects a LINE Things.
  */
-@Value
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonTypeName("things")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE, onConstructor = @__(@Deprecated))
+// TODO: Remove next release. Use builder() instead.
 @JsonDeserialize(builder = ThingsEvent.ThingsEventBuilder.class)
 public class ThingsEvent implements Event, ReplyEvent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class ThingsEventBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     /**
      * Token for replying to this event.
      */
@@ -80,15 +85,10 @@ public class ThingsEvent implements Event, ReplyEvent {
      */
     @Deprecated
     public ThingsEvent(
-            @JsonProperty("replyToken") String replyToken,
-            @JsonProperty("source") Source source,
-            @JsonProperty("things") ThingsContent things,
-            @JsonProperty("timestamp") Instant timestamp) {
+            String replyToken,
+            Source source,
+            ThingsContent things,
+            Instant timestamp) {
         this(replyToken, source, things, timestamp, null);
-    }
-
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class ThingsEventBuilder {
-        // Filled by lombok
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/UnfollowEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/UnfollowEvent.java
@@ -18,7 +18,6 @@ package com.linecorp.bot.model.event;
 
 import java.time.Instant;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -33,12 +32,18 @@ import lombok.Value;
 /**
  * Event object for when your account is blocked.
  */
-@Value
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonTypeName("unfollow")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE, onConstructor = @__(@Deprecated))
+// TODO: Remove next release. Use builder() instead.
 @JsonDeserialize(builder = UnfollowEvent.UnfollowEventBuilder.class)
 public class UnfollowEvent implements Event {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class UnfollowEventBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     /**
      * JSON object which contains the source of the event.
      */
@@ -69,13 +74,8 @@ public class UnfollowEvent implements Event {
      */
     @Deprecated
     public UnfollowEvent(
-            @JsonProperty("source") final Source source,
-            @JsonProperty("timestamp") final Instant timestamp) {
+            final Source source,
+            final Instant timestamp) {
         this(source, timestamp, null);
-    }
-
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class UnfollowEventBuilder {
-        // Filled by lombok
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/UnknownEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/UnknownEvent.java
@@ -18,7 +18,6 @@ package com.linecorp.bot.model.event;
 
 import java.time.Instant;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -33,10 +32,16 @@ import lombok.Value;
  * Fallback event type for {@link Event}.
  */
 @Value
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(toBuilder = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE, onConstructor = @__(@Deprecated))
+// TODO: Remove next release. Use builder() instead.
 @JsonDeserialize(builder = UnknownEvent.UnknownEventBuilder.class)
 public class UnknownEvent implements Event {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class UnknownEventBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     /**
      * Type of the event.
      */
@@ -72,14 +77,9 @@ public class UnknownEvent implements Event {
      */
     @Deprecated
     public UnknownEvent(
-            @JsonProperty("type") final String type,
-            @JsonProperty("source") final Source source,
-            @JsonProperty("timestamp") final Instant timestamp) {
+            final String type,
+            final Source source,
+            final Instant timestamp) {
         this(type, source, timestamp, null);
-    }
-
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class UnknownEventBuilder {
-        // Filled by lombok
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/link/LinkContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/link/LinkContent.java
@@ -16,16 +16,27 @@
 
 package com.linecorp.bot.model.event.link;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 /**
  * Content of the link account event.
  */
 @Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = LinkContent.LinkContentBuilder.class)
 public class LinkContent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class LinkContentBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     /**
      * One of the following values to indicate whether the link was successful or not.
      *
@@ -37,13 +48,6 @@ public class LinkContent {
      * Specified nonce when verifying the user ID.
      */
     String nonce;
-
-    @JsonCreator
-    public LinkContent(@JsonProperty("result") Result result,
-                       @JsonProperty("nonce") String nonce) {
-        this.result = result;
-        this.nonce = nonce;
-    }
 
     public enum Result {
         /** Indicates the link was successful. */

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/AudioMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/AudioMessageContent.java
@@ -16,28 +16,29 @@
 
 package com.linecorp.bot.model.event.message;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 /**
  * Message content for audio type.
  */
-@Value
 @JsonTypeName("audio")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = AudioMessageContent.AudioMessageContentBuilder.class)
 public class AudioMessageContent implements MessageContent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class AudioMessageContentBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     String id;
     ContentProvider contentProvider;
     Integer duration;
-
-    @JsonCreator
-    public AudioMessageContent(@JsonProperty("id") final String id,
-                               @JsonProperty("duration") final Integer duration,
-                               @JsonProperty("contentProvider") final ContentProvider contentProvider) {
-        this.id = id;
-        this.contentProvider = contentProvider;
-        this.duration = duration;
-    }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/ContentProvider.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/ContentProvider.java
@@ -18,14 +18,24 @@ package com.linecorp.bot.model.event.message;
 
 import java.net.URI;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 @Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = ContentProvider.ContentProviderBuilder.class)
 public class ContentProvider {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class ContentProviderBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     private static final String LINE = "line";
     private static final String EXTERNAL = "external";
 
@@ -47,15 +57,6 @@ public class ContentProvider {
      * URL of the preview resource. Only included when {@link #type} is {@link #EXTERNAL}.
      */
     URI previewImageUrl;
-
-    @JsonCreator
-    public ContentProvider(@JsonProperty("type") String type,
-                           @JsonProperty("originalContentUrl") URI originalContentUrl,
-                           @JsonProperty("previewImageUrl") URI previewImageUrl) {
-        this.type = type;
-        this.originalContentUrl = originalContentUrl;
-        this.previewImageUrl = previewImageUrl;
-    }
 
     @JsonIgnore
     public boolean isExternal() {

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/FileMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/FileMessageContent.java
@@ -16,26 +16,26 @@
 
 package com.linecorp.bot.model.event.message;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
-@Value
 @JsonTypeName("file")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = FileMessageContent.FileMessageContentBuilder.class)
 public class FileMessageContent implements MessageContent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class FileMessageContentBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     String id;
     String fileName;
     int fileSize;
-
-    @JsonCreator
-    public FileMessageContent(
-            @JsonProperty("id") final String id,
-            @JsonProperty("fileName") final String fileName,
-            @JsonProperty("fileSize") final int fileSize) {
-        this.id = id;
-        this.fileName = fileName;
-        this.fileSize = fileSize;
-    }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/ImageMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/ImageMessageContent.java
@@ -16,25 +16,28 @@
 
 package com.linecorp.bot.model.event.message;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 /**
  * Message content for image type.
  */
-@Value
 @JsonTypeName("image")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = ImageMessageContent.ImageMessageContentBuilder.class)
 public class ImageMessageContent implements MessageContent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class ImageMessageContentBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     String id;
     ContentProvider contentProvider;
-
-    @JsonCreator
-    public ImageMessageContent(@JsonProperty("id") final String id,
-                               @JsonProperty("contentProvider") final ContentProvider contentProvider) {
-        this.id = id;
-        this.contentProvider = contentProvider;
-    }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/LocationMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/LocationMessageContent.java
@@ -16,18 +16,28 @@
 
 package com.linecorp.bot.model.event.message;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 /**
  * Message content for location type.
  */
-@Value
 @JsonTypeName("location")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = LocationMessageContent.LocationMessageContentBuilder.class)
 public class LocationMessageContent implements MessageContent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class LocationMessageContentBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     String id;
 
     /**
@@ -49,18 +59,4 @@ public class LocationMessageContent implements MessageContent {
      * Longitude.
      */
     double longitude;
-
-    @JsonCreator
-    public LocationMessageContent(
-            @JsonProperty("id") final String id,
-            @JsonProperty("title") final String title,
-            @JsonProperty("address") final String address,
-            @JsonProperty("latitude") final double latitude,
-            @JsonProperty("longitude") final double longitude) {
-        this.id = id;
-        this.title = title;
-        this.address = address;
-        this.latitude = latitude;
-        this.longitude = longitude;
-    }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/StickerMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/StickerMessageContent.java
@@ -16,29 +16,29 @@
 
 package com.linecorp.bot.model.event.message;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 /**
  * Message content for sticker type.
  */
-@Value
 @JsonTypeName("sticker")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = StickerMessageContent.StickerMessageContentBuilder.class)
 public class StickerMessageContent implements MessageContent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class StickerMessageContentBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     String id;
     String packageId;
     String stickerId;
-
-    @JsonCreator
-    public StickerMessageContent(
-            @JsonProperty("id") final String id,
-            @JsonProperty("packageId") final String packageId,
-            @JsonProperty("stickerId") final String stickerId) {
-        this.id = id;
-        this.packageId = packageId;
-        this.stickerId = stickerId;
-    }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/TextMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/TextMessageContent.java
@@ -16,30 +16,32 @@
 
 package com.linecorp.bot.model.event.message;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 /**
  * Message content for text.
  */
-@Value
 @JsonTypeName("text")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = TextMessageContent.TextMessageContentBuilder.class)
 public class TextMessageContent implements MessageContent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class TextMessageContentBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     String id;
 
     /**
      * Message text.
      */
     String text;
-
-    @JsonCreator
-    public TextMessageContent(
-            @JsonProperty("id") final String id,
-            @JsonProperty("text") final String text) {
-        this.id = id;
-        this.text = text;
-    }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/UnknownMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/UnknownMessageContent.java
@@ -16,20 +16,25 @@
 
 package com.linecorp.bot.model.event.message;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 /**
  * Fallback message content type for {@link MessageContent}.
  */
 @Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = UnknownMessageContent.UnknownMessageContentBuilder.class)
 public class UnknownMessageContent implements MessageContent {
-    String id;
-
-    @JsonCreator
-    public UnknownMessageContent(@JsonProperty("id") final String id) {
-        this.id = id;
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class UnknownMessageContentBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
     }
+
+    String id;
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/VideoMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/VideoMessageContent.java
@@ -16,25 +16,26 @@
 
 package com.linecorp.bot.model.event.message;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
-@Value
 @JsonTypeName("video")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = VideoMessageContent.VideoMessageContentBuilder.class)
 public class VideoMessageContent implements MessageContent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class VideoMessageContentBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     String id;
     String url;
     ContentProvider contentProvider;
-
-    @JsonCreator
-    public VideoMessageContent(@JsonProperty("id") final String id,
-                               @JsonProperty("url") final String url,
-                               @JsonProperty("contentProvider") final ContentProvider contentProvider) {
-        this.id = id;
-        this.url = url;
-        this.contentProvider = contentProvider;
-    }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/postback/PostbackContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/postback/PostbackContent.java
@@ -18,27 +18,29 @@ package com.linecorp.bot.model.event.postback;
 
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 /**
  * Content of the postback event.
  */
 @Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = PostbackContent.PostbackContentBuilder.class)
 public class PostbackContent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class PostbackContentBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     /**
      * Postback data.
      */
     String data;
     Map<String, String> params;
-
-    @JsonCreator
-    public PostbackContent(
-            @JsonProperty("data") final String data,
-            @JsonProperty("params") final Map<String, String> params) {
-        this.data = data;
-        this.params = params;
-    }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/GroupSource.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/GroupSource.java
@@ -16,31 +16,27 @@
 
 package com.linecorp.bot.model.event.source;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
-@Value
 @JsonTypeName("group")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = GroupSource.GroupSourceBuilder.class)
 public class GroupSource implements Source {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class GroupSourceBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     String groupId;
     String userId;
-
-    /**
-     * Create new instance.
-     *
-     * @param groupId group ID
-     * @param userId user id may be null
-     */
-    @JsonCreator
-    public GroupSource(
-            @JsonProperty("groupId") final String groupId,
-            @JsonProperty("userId") final String userId) {
-        this.groupId = groupId;
-        this.userId = userId;
-    }
 
     @Override
     public String getSenderId() {

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/RoomSource.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/RoomSource.java
@@ -16,25 +16,27 @@
 
 package com.linecorp.bot.model.event.source;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
-@Value
 @JsonTypeName("room")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = RoomSource.RoomSourceBuilder.class)
 public class RoomSource implements Source {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class RoomSourceBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     String userId;
     String roomId;
-
-    @JsonCreator
-    public RoomSource(
-            @JsonProperty("userId") final String userId,
-            @JsonProperty("roomId") final String roomId) {
-        this.userId = userId;
-        this.roomId = roomId;
-    }
 
     @Override
     public String getSenderId() {

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/UnknownSource.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/UnknownSource.java
@@ -16,13 +16,26 @@
 
 package com.linecorp.bot.model.event.source;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 /**
  * Fallback source type for {@link Source}.
  */
 @Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = UnknownSource.UnknownSourceBuilder.class)
 public class UnknownSource implements Source {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class UnknownSourceBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     @Override
     public String getUserId() {
         return null;

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/UserSource.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/source/UserSource.java
@@ -16,21 +16,26 @@
 
 package com.linecorp.bot.model.event.source;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
-@Value
 @JsonTypeName("user")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = UserSource.UserSourceBuilder.class)
 public class UserSource implements Source {
-    String userId;
-
-    @JsonCreator
-    public UserSource(@JsonProperty("userId") final String userId) {
-        this.userId = userId;
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class UserSourceBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
     }
+
+    String userId;
 
     @Override
     public String getSenderId() {

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/LinkThingsContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/LinkThingsContent.java
@@ -16,19 +16,24 @@
 
 package com.linecorp.bot.model.event.things;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
-@Value
 @JsonTypeName("link")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = LinkThingsContent.LinkThingsContentBuilder.class)
 public class LinkThingsContent implements ThingsContent {
-    String deviceId;
-
-    @JsonCreator
-    public LinkThingsContent(@JsonProperty("deviceId") final String deviceId) {
-        this.deviceId = deviceId;
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class LinkThingsContentBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
     }
+
+    String deviceId;
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/ScenarioResultThingsContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/ScenarioResultThingsContent.java
@@ -16,26 +16,27 @@
 
 package com.linecorp.bot.model.event.things;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import com.linecorp.bot.model.event.things.result.ScenarioResult;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
-@Value
 @JsonTypeName("scenarioResult")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = ScenarioResultThingsContent.ScenarioResultThingsContentBuilder.class)
 public class ScenarioResultThingsContent implements ThingsContent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class ScenarioResultThingsContentBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     String deviceId;
     ScenarioResult result;
-
-    @JsonCreator
-    public ScenarioResultThingsContent(
-            @JsonProperty("deviceId") String deviceId,
-            @JsonProperty("result") ScenarioResult result
-    ) {
-        this.deviceId = deviceId;
-        this.result = result;
-    }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/UnknownLineThingsContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/UnknownLineThingsContent.java
@@ -16,10 +16,26 @@
 
 package com.linecorp.bot.model.event.things;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
 /**
  * Fallback for {@link ThingsContent}.
  */
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = UnknownLineThingsContent.UnknownLineThingsContentBuilder.class)
 public class UnknownLineThingsContent implements ThingsContent {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class UnknownLineThingsContentBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     @Override
     public String getDeviceId() {
         return null;

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/UnlinkThingsContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/UnlinkThingsContent.java
@@ -16,19 +16,24 @@
 
 package com.linecorp.bot.model.event.things;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
-@Value
 @JsonTypeName("unlink")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = UnlinkThingsContent.UnlinkThingsContentBuilder.class)
 public class UnlinkThingsContent implements ThingsContent {
-    String deviceId;
-
-    @JsonCreator
-    public UnlinkThingsContent(@JsonProperty("deviceId") final String deviceId) {
-        this.deviceId = deviceId;
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class UnlinkThingsContentBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
     }
+
+    String deviceId;
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/BinaryActionResult.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/BinaryActionResult.java
@@ -16,19 +16,24 @@
 
 package com.linecorp.bot.model.event.things.result;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
-@Value
 @JsonTypeName("binary")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = BinaryActionResult.BinaryActionResultBuilder.class)
 public class BinaryActionResult implements ActionResult {
-    String data;
-
-    @JsonCreator
-    public BinaryActionResult(@JsonProperty("data") final String data) {
-        this.data = data;
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class BinaryActionResultBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
     }
+
+    String data;
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/ScenarioResult.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/ScenarioResult.java
@@ -19,13 +19,23 @@ package com.linecorp.bot.model.event.things.result;
 import java.time.Instant;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 @Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = ScenarioResult.ScenarioResultBuilder.class)
 public class ScenarioResult {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class ScenarioResultBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
     String scenarioId;
     long revision;
     Instant startTime;
@@ -34,25 +44,4 @@ public class ScenarioResult {
     List<ActionResult> actionResults;
     String bleNotificationPayload;
     String errorReason;
-
-    @JsonCreator
-    ScenarioResult(
-            @JsonProperty("scenarioId") String scenarioId,
-            @JsonProperty("revision") long revision,
-            @JsonProperty("startTime") Instant startTime,
-            @JsonProperty("endTime") Instant endTime,
-            @JsonProperty("resultCode") String resultCode,
-            @JsonProperty("actionResults") List<ActionResult> actionResults,
-            @JsonProperty("bleNotificationPayload") String bleNotificationPayload,
-            @JsonProperty("errorReason") String errorReason
-    ) {
-        this.scenarioId = scenarioId;
-        this.revision = revision;
-        this.startTime = startTime;
-        this.endTime = endTime;
-        this.resultCode = resultCode;
-        this.actionResults = actionResults;
-        this.bleNotificationPayload = bleNotificationPayload;
-        this.errorReason = errorReason;
-    }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/UnknownActionResult.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/UnknownActionResult.java
@@ -16,5 +16,21 @@
 
 package com.linecorp.bot.model.event.things.result;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = UnknownActionResult.UnknownActionResultBuilder.class)
 public class UnknownActionResult implements ActionResult {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class UnknownActionResultBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/VoidActionResult.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/VoidActionResult.java
@@ -17,7 +17,22 @@
 package com.linecorp.bot.model.event.things.result;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
 
 @JsonTypeName("void")
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor(onConstructor = @__(@Deprecated)) // TODO: Remove next release. Use builder() instead.
+@JsonDeserialize(builder = VoidActionResult.VoidActionResultBuilder.class)
 public class VoidActionResult implements ActionResult {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class VoidActionResultBuilder {
+        // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
 }


### PR DESCRIPTION
* Add `XxxBuilder` for lombok.
```
    public static class AccountLinkEventBuilder {
        // Providing builder instead of public constructor. Class body is filled by lombok.
    }
```

* Replace manual writen @JsonCreator constructor with `@AllArgsConstructor(onConstructor = @__(@Deprecated))`
  * Those constructor not used for Jackson from this PR.

* Already added AllArgsConstructor also marked `@__(@Deprecated)`.

* Remove redundant `@JsonProperty` for constructo don't used json deserialize.