### PR TITLE
Fix missing/empty LocationAction label

### DIFF
--- a/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/MessageWithQuickReplySupplier.java
+++ b/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/MessageWithQuickReplySupplier.java
@@ -44,7 +44,7 @@ public class MessageWithQuickReplySupplier implements Supplier<Message> {
                               .action(CameraRollAction.withLabel("CemeraRollAction"))
                               .build(),
                 QuickReplyItem.builder()
-                              .action(LocationAction.withLabel(""))
+                              .action(LocationAction.withLabel("Location"))
                               .build(),
                 QuickReplyItem.builder()
                               .action(PostbackAction.builder()


### PR DESCRIPTION
I received following error during testing the sample kitchensink-app's quickreply support:
 {"message":"The request body has 1 error(s)","details":[{"message":"`label` must be specified","property":"messages[0].quickReply.items[3].action"}]}
Changing the label from "" to "Location" fixed it.