### PR TITLE
NON-ISSUE Extends test timeout.

### DIFF
--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/CallbackAdaptorTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/CallbackAdaptorTest.java
@@ -43,7 +43,7 @@ public class CallbackAdaptorTest {
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Rule
-    public final Timeout timeoutRule = Timeout.seconds(1);
+    public final Timeout timeoutRule = Timeout.seconds(10);
 
     @Mock
     private Call<Object> call;


### PR DESCRIPTION
Build is unstable due to timeout is too slow in some build environment