### PR TITLE
Add account link event model

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/AccountLinkEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/AccountLinkEvent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.event;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.linecorp.bot.model.event.link.LinkContent;
+import com.linecorp.bot.model.event.source.Source;
+import lombok.Value;
+
+import java.time.Instant;
+
+/**
+ * Event object for when a user has linked his/her LINE account with a provider's service account.
+ * You can reply to account link events.
+ */
+@Value
+@JsonTypeName("accountLink")
+public class AccountLinkEvent implements Event, ReplyEvent {
+    /**
+     * Token for replying to this event.
+     */
+    private final String replyToken;
+
+    /**
+     * JSON object which contains the source of the event.
+     */
+    private final Source source;
+
+    /**
+     * Time of the event.
+     */
+    private final Instant timestamp;
+
+    /**
+     * Content of the account link event.
+     */
+    private final LinkContent link;
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/AccountLinkEvent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/AccountLinkEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2018 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,12 +16,14 @@
 
 package com.linecorp.bot.model.event;
 
+import java.time.Instant;
+
 import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import com.linecorp.bot.model.event.link.LinkContent;
 import com.linecorp.bot.model.event.source.Source;
-import lombok.Value;
 
-import java.time.Instant;
+import lombok.Value;
 
 /**
  * Event object for when a user has linked his/her LINE account with a provider's service account.

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/Event.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/Event.java
@@ -33,7 +33,8 @@ import com.linecorp.bot.model.event.source.Source;
         @JsonSubTypes.Type(JoinEvent.class),
         @JsonSubTypes.Type(LeaveEvent.class),
         @JsonSubTypes.Type(PostbackEvent.class),
-        @JsonSubTypes.Type(BeaconEvent.class)
+        @JsonSubTypes.Type(BeaconEvent.class),
+        @JsonSubTypes.Type(AccountLinkEvent.class)
 })
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/link/LinkContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/link/LinkContent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.event.link;
+
+import lombok.Value;
+
+/**
+ * Content of the link account event.
+ */
+@Value
+public class LinkContent {
+    /**
+     * One of the following values to indicate whether the link was successful or not.
+     * ok    : Indicates the link was successful.
+     * failed: Indicates the link failed for any reason, such as due to a user impersonation.
+     */
+    private final String result;
+
+    /**
+     * Specified nonce when verifying the user ID
+     */
+    private final String nonce;
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/link/LinkContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/link/LinkContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 LINE Corporation
+ * Copyright 2018 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,6 +16,8 @@
 
 package com.linecorp.bot.model.event.link;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Value;
 
 /**
@@ -25,13 +27,22 @@ import lombok.Value;
 public class LinkContent {
     /**
      * One of the following values to indicate whether the link was successful or not.
-     * ok    : Indicates the link was successful.
-     * failed: Indicates the link failed for any reason, such as due to a user impersonation.
+     *
+     * @see Result
      */
-    private final String result;
+    private final Result result;
 
     /**
-     * Specified nonce when verifying the user ID
+     * Specified nonce when verifying the user ID.
      */
     private final String nonce;
+
+    public enum Result {
+        /** Indicates the link was successful. */
+        @JsonProperty("ok")
+        OK,
+        /** Indicates the link failed for any reason, such as due to a user impersonation. */
+        @JsonProperty("failed")
+        FAILED,
+    }
 }

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
@@ -28,6 +28,7 @@ import org.springframework.util.StreamUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.linecorp.bot.model.event.link.LinkContent;
 import com.linecorp.bot.model.event.message.FileMessageContent;
 import com.linecorp.bot.model.event.message.ImageMessageContent;
 import com.linecorp.bot.model.event.message.LocationMessageContent;
@@ -336,7 +337,7 @@ public class CallbackRequestTest {
 
             AccountLinkEvent accountLinkEvent = (AccountLinkEvent) event;
             assertThat(accountLinkEvent.getLink().getResult())
-                    .isEqualTo("ok");
+                    .isEqualTo(LinkContent.Result.OK);
             assertThat(accountLinkEvent.getLink().getNonce())
                     .isEqualTo("xxxxxxxxxxxxxxx");
         });

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
@@ -321,6 +321,27 @@ public class CallbackRequestTest {
         });
     }
 
+    @Test
+    public void testAccountLink() throws IOException {
+        parse("callback/account_link.json", callbackRequest -> {
+            assertThat(callbackRequest.getEvents()).hasSize(1);
+            Event event = callbackRequest.getEvents().get(0);
+            assertThat(event).isInstanceOf(AccountLinkEvent.class);
+            assertThat(event.getSource())
+                    .isInstanceOf(UserSource.class);
+            assertThat(event.getSource().getUserId())
+                    .isEqualTo("U012345678901234567890123456789ab");
+            assertThat(event.getTimestamp())
+                    .isEqualTo(Instant.parse("2016-05-07T13:57:59.859Z"));
+
+            AccountLinkEvent accountLinkEvent = (AccountLinkEvent) event;
+            assertThat(accountLinkEvent.getLink().getResult())
+                    .isEqualTo("ok");
+            assertThat(accountLinkEvent.getLink().getNonce())
+                    .isEqualTo("xxxxxxxxxxxxxxx");
+        });
+    }
+
     // Event, that has brand new eventType
     @Test
     public void testUnknown() throws IOException {

--- a/line-bot-model/src/test/resources/callback/account_link.json
+++ b/line-bot-model/src/test/resources/callback/account_link.json
@@ -1,0 +1,17 @@
+{
+  "events": [
+    {
+      "replyToken": "nHuyWiB7yP5Zw52FIkcQobQuGDXCTA",
+      "type": "accountLink",
+      "timestamp": 1462629479859,
+      "source": {
+        "type": "user",
+        "userId": "U012345678901234567890123456789ab"
+      },
+      "link": {
+        "result": "ok",
+        "nonce": "xxxxxxxxxxxxxxx"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
I created event model which handle with `Account link event`
https://developers.line.me/en/reference/messaging-api/#account-link-event

### Sample
```
@LineMessageHandler
public class LineBotApi {
    @EventMapping
    public void handleAccountLinkEvent(AccountLinkEvent event) {
        if ("ok".equals(event.getLink().getResult())) {
            String nonce = event.getLink().getNonce();
            String userId = event.getSource().getUserId();
            // Link LINE's userId and your service account using this nonce.
        }
    }
}
```