### PR TITLE
Add universal (?) API call method.

### DIFF
--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClient.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClient.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.bot.client;
 
+import java.net.URI;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -281,6 +282,26 @@ public interface LineMessagingClient {
      * @see <a href="https://developers.line.biz/en/reference/messaging-api/#issue-link-token">Issue link token</a>
      */
     CompletableFuture<IssueLinkTokenResponse> issueLinkToken(String userId);
+
+    /**
+     * Execute GET request to supplied path.
+     *
+     * @param path relative path from api basePath.
+     * @param queryParameter query parameter objects. Basically supplied as Map.
+     *         But otherwise convert to key=value as POJO.
+     * @param clazz result class.
+     */
+    <T> CompletableFuture<T> get(URI path, Object queryParameter, Class<T> clazz);
+
+    /**
+     * Execute POST request to supplied path.
+     *
+     * @param path see {@link #get(URI, Object, Class)}
+     * @param queryParameter see {@link #get(URI, Object, Class)}
+     * @param jsonBody Request body. Converted to JSON.
+     * @param clazz see {@link #get(URI, Object, Class)}
+     */
+    <T> CompletableFuture<T> post(URI path, Object queryParameter, Object jsonBody, Class<T> clazz);
 
     static LineMessagingClientBuilder builder(String channelToken) {
         return builder(FixedChannelTokenSupplier.of(channelToken));

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingService.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingService.java
@@ -16,7 +16,9 @@
 
 package com.linecorp.bot.client;
 
+import java.net.URI;
 import java.util.List;
+import java.util.Map;
 
 import com.linecorp.bot.model.Multicast;
 import com.linecorp.bot.model.PushMessage;
@@ -42,6 +44,7 @@ import retrofit2.http.GET;
 import retrofit2.http.POST;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
+import retrofit2.http.QueryMap;
 import retrofit2.http.Streaming;
 
 /**
@@ -283,4 +286,25 @@ interface LineMessagingService {
      */
     @POST("v2/bot/user/{userId}/linkToken")
     Call<IssueLinkTokenResponse> issueLinkToken(@Path("userId") String userId);
+
+    /**
+     * Method for Retrofit.
+     *
+     * @see LineMessagingClient#get(URI, Object, Class)
+     */
+    @GET("{path}")
+    Call<ResponseBody> get(
+            @Path(value = "path", encoded = true) URI path,
+            @QueryMap Map<String, Object> queryMap);
+
+    /**
+     * Method for Retrofit.
+     *
+     * @see LineMessagingClient#post(URI, Object, Object, Class)
+     */
+    @POST("{path}")
+    Call<ResponseBody> post(
+            @Path(value = "path", encoded = true) URI path,
+            @QueryMap Map<String, Object> queryMap,
+            @Body Object postBody);
 }

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/AbstractWiremockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/AbstractWiremockTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
 import com.linecorp.bot.model.error.ErrorResponse;
+import com.linecorp.bot.model.objectmapper.ModelObjectMapper;
 
 import lombok.SneakyThrows;
 import okhttp3.mockwebserver.MockResponse;
@@ -33,6 +34,7 @@ import okhttp3.mockwebserver.MockWebServer;
 
 public abstract class AbstractWiremockTest {
     public static final int ASYNC_TEST_TIMEOUT = 1_000;
+    private static final ObjectWriter RESPONSE_WRITER = ModelObjectMapper.createNewObjectMapper().writer();
     private static final ObjectWriter ERROR_RESPONSE_READER = new ObjectMapper().writerFor(ErrorResponse.class);
 
     static {
@@ -62,6 +64,14 @@ public abstract class AbstractWiremockTest {
                 .enqueue(new MockResponse()
                                  .setResponseCode(responseCode)
                                  .setBody(ERROR_RESPONSE_READER.writeValueAsString(errorResponse)));
+    }
+
+    @SneakyThrows
+    public void mocking(final int responseCode, final Object responseBodyObject) {
+        mockWebServer
+                .enqueue(new MockResponse()
+                                 .setResponseCode(responseCode)
+                                 .setBody(RESPONSE_WRITER.writeValueAsString(responseBodyObject)));
     }
 
     protected LineMessagingClient createLineMessagingClient(final MockWebServer mockWebServer) {

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplGetPostWiremockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplGetPostWiremockTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import com.linecorp.bot.client.exception.BadRequestException;
+import com.linecorp.bot.model.error.ErrorDetail;
+import com.linecorp.bot.model.error.ErrorResponse;
+import com.linecorp.bot.model.response.BotApiResponse;
+
+import okhttp3.mockwebserver.RecordedRequest;
+
+public class LineMessagingClientImplGetPostWiremockTest extends AbstractWiremockTest {
+    @Rule
+    public final Timeout timeoutRule = Timeout.seconds(5);
+
+    @Test
+    public void testGet() throws Exception {
+        // Mocking
+        final BotApiResponse mockResponse = new BotApiResponse("OK", singletonList("Sample"));
+        mocking(200, mockResponse);
+
+        // Do
+        final BotApiResponse response =
+                lineMessagingClient.get(URI.create("path/subPath"),
+                                        singletonMap("key", "value"), BotApiResponse.class).get();
+
+        // Verify
+        assertThat(response).isEqualTo(mockResponse);
+
+        final RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        assertThat(recordedRequest.getPath())
+                .isEqualTo("/path/subPath?key=value");
+    }
+
+    @Test
+    public void testPost() throws Exception {
+        // Mocking
+        final BotApiResponse mockResponse = new BotApiResponse("OK", singletonList("Sample"));
+        mocking(200, mockResponse);
+
+        // Do
+        final BotApiResponse response =
+                lineMessagingClient.post(URI.create("path/subPath"),
+                                         singletonMap("key", "value"),
+                                         singleton("RequestBody"),
+                                         BotApiResponse.class).get();
+
+        // Verify
+        assertThat(response).isEqualTo(mockResponse);
+
+        final RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        assertThat(recordedRequest.getPath())
+                .isEqualTo("/path/subPath?key=value");
+        assertThat(recordedRequest.getBody().readUtf8())
+                .isEqualTo("[\"RequestBody\"]");
+    }
+
+    @Test
+    public void test400FollowsBadRequestException() throws Exception {
+        final ErrorResponse errorResponse =
+                new ErrorResponse("requestId", "message", singletonList(new ErrorDetail("key", "value")));
+        mocking(400, errorResponse);
+
+        // Do
+        final CompletableFuture<BotApiResponse> completableFuture =
+                lineMessagingClient.get(
+                        URI.create("path/subPath"),
+                        singletonMap("key", "value"), BotApiResponse.class);
+
+        // Verify
+        try {
+            completableFuture.get();
+        } catch (Exception ignored) {
+        }
+
+        assertThat(completableFuture)
+                .hasFailedWithThrowableThat()
+                .isExactlyInstanceOf(BadRequestException.class);
+    }
+}

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplTest.java
@@ -18,6 +18,7 @@ package com.linecorp.bot.client;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -26,7 +27,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.net.URI;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Collections;
+import java.util.Map;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -402,7 +406,42 @@ public class LineMessagingClientImplTest {
         // Verify
         verify(retrofitMock, only()).getRichMenuList();
         assertThat(richMenuListResponse.getRichMenus()).isEmpty();
+    }
 
+    @Test
+    public void getTest() throws Exception {
+        whenCall(retrofitMock.get(any(), any()),
+                 ResponseBody.create(MediaType.parse("application/json"), "{\"key\":\"response\"}"));
+
+        // Do
+        @SuppressWarnings({ "rawtype", "unchecked" })
+        final Map<String, Object> richMenuListResponse =
+                target.get(URI.create("v3/newapi"), singletonMap("key", "request"), Map.class).get();
+
+        // Verify
+        verify(retrofitMock, only()).get(any(), any());
+        assertThat(richMenuListResponse)
+                .hasSize(1)
+                .containsOnly(new SimpleEntry<>("key", "response"));
+    }
+
+    @Test
+    public void postTest() throws Exception {
+        whenCall(retrofitMock.post(any(), any(), any()),
+                 ResponseBody.create(MediaType.parse("application/json"), "{\"key\":\"response\"}"));
+
+        final Map<String, String> postBody = singletonMap("key", "body");
+
+        // Do
+        @SuppressWarnings({ "rawtype", "unchecked" })
+        final Map<String, Object> richMenuListResponse =
+                target.post(URI.create("v3/newapi"), singletonMap("key", "request"), postBody, Map.class).get();
+
+        // Verify
+        verify(retrofitMock, only()).post(any(), any(), eq(postBody));
+        assertThat(richMenuListResponse)
+                .hasSize(1)
+                .containsOnly(new SimpleEntry<>("key", "response"));
     }
 
     @Test


### PR DESCRIPTION
Sometimes SDK can't catch up API improvement and cutting-edge provider can't use LINE Bot SDK.

In such case, users can call new API using this method until this SDK supports it.