### PR TITLE
Custom aspect ratio for Image component

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Image.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Image.java
@@ -62,30 +62,28 @@ public class Image implements FlexComponent {
     }
 
     public enum ImageAspectRatio {
-        @JsonProperty("1:1")
-        R1TO1,
-        @JsonProperty("20:13")
-        R20TO13,
-        @JsonProperty("1.91:1")
-        R1_91TO1,
-        @JsonProperty("4:3")
-        R4TO3,
-        @JsonProperty("16:9")
-        R16TO9,
-        @JsonProperty("2:1")
-        R2TO1,
-        @JsonProperty("3:1")
-        R3TO1,
-        @JsonProperty("3:4")
-        R3TO4,
-        @JsonProperty("9:16")
-        R9TO16,
-        @JsonProperty("1:2")
-        R1TO2,
-        @JsonProperty("1:3")
-        R1TO3,
-        @JsonProperty("1.51:1")
-        R1_51TO1,
+        R1TO1("1:1"),
+        R20TO13("20:13"),
+        R1_91TO1("1.91:1"),
+        R4TO3("4:3"),
+        R16TO9("16:9"),
+        R2TO1("2:1"),
+        R3TO1("3:1"),
+        R3TO4("3:4"),
+        R9TO16("9:16"),
+        R1TO2("1:2"),
+        R1TO3("1:3"),
+        R1_51TO1("1.51:1");
+
+        private final String ratio;
+
+        ImageAspectRatio(String ratio) {
+            this.ratio = ratio;
+        }
+
+        public String getRatio() {
+            return ratio;
+        }
     }
 
     public enum ImageAspectMode {
@@ -101,7 +99,7 @@ public class Image implements FlexComponent {
 
     private final ImageSize size;
 
-    private final ImageAspectRatio aspectRatio;
+    private final String aspectRatio;
 
     private final ImageAspectMode aspectMode;
 
@@ -120,7 +118,7 @@ public class Image implements FlexComponent {
             @JsonProperty("flex") Integer flex,
             @JsonProperty("url") String url,
             @JsonProperty("size") ImageSize size,
-            @JsonProperty("aspectRatio") ImageAspectRatio aspectRatio,
+            @JsonProperty("aspectRatio") String aspectRatio,
             @JsonProperty("aspectMode") ImageAspectMode aspectMode,
             @JsonProperty("backgroundColor") String backgroundColor,
             @JsonProperty("align") FlexAlign align,
@@ -137,5 +135,38 @@ public class Image implements FlexComponent {
         this.action = action;
         this.gravity = gravity;
         this.margin = margin;
+    }
+
+    public Image(
+            Integer flex,
+            String url,
+            ImageSize size,
+            ImageAspectRatio aspectRatio,
+            ImageAspectMode aspectMode,
+            String backgroundColor,
+            FlexAlign align,
+            Action action,
+            FlexGravity gravity,
+            FlexMarginSize margin) {
+        this(flex, url, size, aspectRatio.getRatio(), aspectMode, backgroundColor, align, action,
+             gravity, margin);
+    }
+
+    public static class ImageBuilder {
+        /**
+         * Specify aspect ratio by keyword.
+         */
+        public ImageBuilder aspectRatio(ImageAspectRatio aspectRatio) {
+            this.aspectRatio = aspectRatio.getRatio();
+            return this;
+        }
+
+        /**
+         * Specify custom aspect ratio.
+         */
+        public ImageBuilder aspectRatio(String aspectRatio) {
+            this.aspectRatio = aspectRatio;
+            return this;
+        }
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Image.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Image.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.bot.model.message.flex.component;
 
+import java.text.DecimalFormat;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -153,6 +155,9 @@ public class Image implements FlexComponent {
     }
 
     public static class ImageBuilder {
+
+        private static final DecimalFormat RATIO_FORMAT = new DecimalFormat("0.#####");
+
         /**
          * Specify aspect ratio by keyword.
          */
@@ -166,6 +171,14 @@ public class Image implements FlexComponent {
          */
         public ImageBuilder aspectRatio(String aspectRatio) {
             this.aspectRatio = aspectRatio;
+            return this;
+        }
+
+        /**
+         * Specify custom aspect ratio. The width and height are rounded up to 5 decimal places.
+         */
+        public ImageBuilder aspectRatio(double width, double height) {
+            this.aspectRatio = RATIO_FORMAT.format(width) + ":" + RATIO_FORMAT.format(height);
             return this;
         }
     }

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/message/flex/component/ImageAspectRatioFormatTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/message/flex/component/ImageAspectRatioFormatTest.java
@@ -1,0 +1,54 @@
+package com.linecorp.bot.model.message.flex.component;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.linecorp.bot.model.message.flex.component.Image.ImageBuilder;
+
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+@Value
+@RunWith(Parameterized.class)
+public class ImageAspectRatioFormatTest {
+
+    @Value
+    @AllArgsConstructor
+    public static class Fixture {
+        private double width;
+        private double height;
+        private String result;
+    }
+
+    private static List<Fixture> VALUES = Arrays.asList(
+            new Fixture(1, 1, "1:1"),
+            new Fixture(1.01, 1.01, "1.01:1.01"),
+            new Fixture(100000, 100000, "100000:100000"),
+            new Fixture(Math.PI, Math.PI, "3.14159:3.14159")
+    );
+
+    @Parameters(name = "{0}")
+    public static Iterable<Fixture[]> testData() {
+        return VALUES.stream().map(x -> new Fixture[] { x }).collect(Collectors.toList());
+    }
+
+    private final Fixture fixture;
+
+    @Test
+    public void test() {
+        final Image image =
+                new ImageBuilder()
+                        .aspectRatio(fixture.getWidth(), fixture.getHeight())
+                        .build();
+        assertThat(image.getAspectRatio()).isEqualTo(fixture.getResult());
+    }
+}

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/message/flex/component/ImageAspectRatioFormatTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/message/flex/component/ImageAspectRatioFormatTest.java
@@ -1,5 +1,20 @@
-package com.linecorp.bot.model.message.flex.component;
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 
+package com.linecorp.bot.model.message.flex.component;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
By recent update, Image component can accept custom aspect ratio rather than pre-defined keywords.

**Note that this is a breaking change.**

See Also
https://developers.line.biz/en/reference/messaging-api/#f-image