### PR TITLE
Fix NPE when logging null exception's cause

### DIFF
--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupport.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupport.java
@@ -180,7 +180,8 @@ public class LineMessageHandlerSupport {
             dispatchInternal(event);
         } catch (InvocationTargetException e) {
             log.trace("InvocationTargetException occurred.", e);
-            log.error(e.getCause().getMessage(), e.getCause());
+            log.error(e.getCause() == null ? e.getMessage() : e.getCause().getMessage(),
+                e.getCause() == null ? e : e.getCause());
         } catch (Error | Exception e) {
             log.error(e.getMessage(), e);
         }

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupport.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupport.java
@@ -180,8 +180,8 @@ public class LineMessageHandlerSupport {
             dispatchInternal(event);
         } catch (InvocationTargetException e) {
             log.trace("InvocationTargetException occurred.", e);
-            log.error(e.getCause() == null ? e.getMessage() : e.getCause().getMessage(),
-                e.getCause() == null ? e : e.getCause());
+            final Throwable t = e.getCause() == null ? e : e.getCause();
+            log.error(t.getMessage(), t);
         } catch (Error | Exception e) {
             log.error(e.getMessage(), e);
         }

--- a/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupport.java
+++ b/line-bot-spring-boot/src/main/java/com/linecorp/bot/spring/boot/support/LineMessageHandlerSupport.java
@@ -179,9 +179,7 @@ public class LineMessageHandlerSupport {
         try {
             dispatchInternal(event);
         } catch (InvocationTargetException e) {
-            log.trace("InvocationTargetException occurred.", e);
-            final Throwable t = e.getCause() == null ? e : e.getCause();
-            log.error(t.getMessage(), t);
+            log.error("InvocationTargetException occurred.", e);
         } catch (Error | Exception e) {
             log.error(e.getMessage(), e);
         }


### PR DESCRIPTION
## Background
Related to an issue raised as #310, this PR tries to offer the resolution by checking whether the thrown exception has `cause` or not.

## Changes
If `InvocationTargetException::getCause` returns `null`, the `log.error` function should print the exception information instead of its cause.