### PR TITLE
Use kotlin 1.3.20 intead of 1.3.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
 // ./gradlew clean && ./gradlew uploadArchives -Prelease
 
 buildscript {
-    ext.kotlin_version = '1.3.11'
+    ext.kotlin_version = '1.3.20'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
Latest gradle prints `The DefaultSourceDirectorySet constructor has been deprecated.` warning.
Upgrading kotlin solves this wanrning.

ref. https://stackoverflow.com/questions/53461821/the-defaultsourcedirectoryset-constructor-has-been-deprecated-how-to-use-the-ob