### PR TITLE
Add LINE channel access token clients

### DIFF
--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineOAuthClient.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineOAuthClient.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.linecorp.bot.model.oauth.ChannelAccessTokenException;
+import com.linecorp.bot.model.oauth.IssueChannelAccessTokenRequest;
+import com.linecorp.bot.model.oauth.IssueChannelAccessTokenResponse;
+
+/**
+ * An OAuth client that issues or revokes channel access tokens. See
+ * <a href="https://developers.line.biz/en/reference/messaging-api/#issue-channel-access-token">document</a>
+ * for detail.
+ */
+public interface LineOAuthClient {
+    /**
+     * Creates a {@link LineOAuthClientBuilder}.
+     */
+    static LineOAuthClientBuilder builder() {
+        return new LineOAuthClientBuilder();
+    }
+
+    /**
+     * Issues a short-lived channel access token. Up to 30 tokens can be issued. If the maximum is exceeded,
+     * existing channel access tokens are revoked in the order of when they were first issued.
+     * It will return a failed {@link CompletableFuture} with {@link ChannelAccessTokenException} if
+     * it has an error during calling the API.
+     */
+    CompletableFuture<IssueChannelAccessTokenResponse> issueChannelToken(IssueChannelAccessTokenRequest req);
+
+    /**
+     * Revokes a channel access token. It will return a failed {@link CompletableFuture} with
+     * {@link ChannelAccessTokenException} if it has an error during calling the API.
+     */
+    CompletableFuture<Void> revokeChannelToken(String accessToken);
+}

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineOAuthClientBuilder.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineOAuthClientBuilder.java
@@ -106,12 +106,10 @@ public class LineOAuthClientBuilder {
     private List<Interceptor> additionalInterceptors = new ArrayList<>();
 
     /**
-     * Set customized OkHttpClient.Builder.
+     * Set customized {@link OkHttpClient.Builder}.
      *
      * <p>In case of you need your own customized {@link OkHttpClient},
      * this builder allows specify {@link OkHttpClient.Builder} instance.
-     *
-     * <p>To use this method, please add dependency to 'com.squareup.retrofit2:retrofit'.
      */
     public LineOAuthClientBuilder okHttpClientBuilder(@NonNull OkHttpClient.Builder okHttpClientBuilder) {
         this.okHttpClientBuilder = okHttpClientBuilder;

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineOAuthClientBuilder.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineOAuthClientBuilder.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import lombok.experimental.PackagePrivate;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
+import okhttp3.logging.HttpLoggingInterceptor.Level;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+@ToString
+@Accessors(fluent = true)
+public class LineOAuthClientBuilder {
+    /**
+     * Creates a {@link LineOAuthClient}. Use {@link LineOAuthClient#builder()} instead.
+     */
+    @PackagePrivate
+    LineOAuthClientBuilder() {
+    }
+
+    /**
+     * API Endpoint.
+     *
+     * <p>Default value = {@value}.
+     */
+    @Setter
+    private String apiEndPoint = LineClientConstants.DEFAULT_API_END_POINT;
+
+    /**
+     * Connection timeout.
+     *
+     * <p>Default value = {@value LineClientConstants#DEFAULT_CONNECT_TIMEOUT_MILLIS}ms.
+     */
+    @Setter
+    private long connectTimeout = LineClientConstants.DEFAULT_CONNECT_TIMEOUT_MILLIS;
+
+    /**
+     * Connection timeout.
+     *
+     * <p>Default value = {@value LineClientConstants#DEFAULT_READ_TIMEOUT_MILLIS}ms.
+     */
+    @Setter
+    private long readTimeout = LineClientConstants.DEFAULT_READ_TIMEOUT_MILLIS;
+
+    /**
+     * Write timeout.
+     *
+     * <p>Default value = {@value LineClientConstants#DEFAULT_WRITE_TIMEOUT_MILLIS}ms.
+     */
+    @Setter
+    private long writeTimeout = LineClientConstants.DEFAULT_WRITE_TIMEOUT_MILLIS;
+
+    /**
+     * Custom {@link Retrofit.Builder} used internally.
+     *
+     * <p>If you want to use your own setting, specify {@link Retrofit.Builder} instance.
+     * Default builder is used in case of {@code null} (default).
+     *
+     * <p>To use this method, please add dependency to 'com.squareup.retrofit2:retrofit'.
+     *
+     * @see #createDefaultRetrofitBuilder()
+     */
+    @Setter
+    private Retrofit.Builder retrofitBuilder;
+
+    private OkHttpClient.Builder okHttpClientBuilder;
+
+    /**
+     * Custom interceptors.
+     *
+     * <p>You can add your own interceptors.
+     */
+    @Setter
+    private List<Interceptor> additionalInterceptors = new ArrayList<>();
+
+    /**
+     * Set customized OkHttpClient.Builder.
+     *
+     * <p>In case of you need your own customized {@link OkHttpClient},
+     * this builder allows specify {@link OkHttpClient.Builder} instance.
+     *
+     * <p>To use this method, please add dependency to 'com.squareup.retrofit2:retrofit'.
+     */
+    public LineOAuthClientBuilder okHttpClientBuilder(@NonNull OkHttpClient.Builder okHttpClientBuilder) {
+        this.okHttpClientBuilder = okHttpClientBuilder;
+        return this;
+    }
+
+    /**
+     * Creates a new {@link LineOAuthService}.
+     */
+    private LineOAuthService buildRetrofit() {
+        if (okHttpClientBuilder == null) {
+            okHttpClientBuilder = new OkHttpClient.Builder();
+        }
+
+        if (additionalInterceptors != null) {
+            additionalInterceptors.forEach(okHttpClientBuilder::addInterceptor);
+        }
+        okHttpClientBuilder.addInterceptor(buildLoggingInterceptor());
+
+        // Set timeout.
+        okHttpClientBuilder
+                .connectTimeout(connectTimeout, TimeUnit.MILLISECONDS)
+                .readTimeout(readTimeout, TimeUnit.MILLISECONDS)
+                .writeTimeout(writeTimeout, TimeUnit.MILLISECONDS);
+
+        final OkHttpClient okHttpClient = okHttpClientBuilder.build();
+
+        if (retrofitBuilder == null) {
+            retrofitBuilder = createDefaultRetrofitBuilder();
+        }
+        retrofitBuilder.client(okHttpClient);
+        retrofitBuilder.baseUrl(apiEndPoint);
+
+        final Retrofit retrofit = retrofitBuilder.build();
+
+        return retrofit.create(LineOAuthService.class);
+    }
+
+    private static Interceptor buildLoggingInterceptor() {
+        final Logger slf4jLogger = LoggerFactory.getLogger("com.linecorp.bot.client.wire");
+
+        return new HttpLoggingInterceptor(slf4jLogger::info)
+                .setLevel(Level.BODY);
+    }
+
+    private static Retrofit.Builder createDefaultRetrofitBuilder() {
+        final ObjectMapper objectMapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                // Register ParameterNamesModule to read parameter name from lombok generated constructor.
+                .registerModule(new ParameterNamesModule())
+                // Register JSR-310(java.time.temporal.*) module and read number as millsec.
+                .registerModule(new JavaTimeModule())
+                .configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
+
+        return new Retrofit.Builder()
+                .addConverterFactory(JacksonConverterFactory.create(objectMapper));
+    }
+
+    /**
+     * Creates a new {@link LineOAuthClient}.
+     */
+    public LineOAuthClient build() {
+        return new LineOAuthClientImpl(buildRetrofit());
+    }
+}

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineOAuthClientImpl.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineOAuthClientImpl.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.linecorp.bot.model.oauth.ChannelAccessTokenException;
+import com.linecorp.bot.model.oauth.IssueChannelAccessTokenRequest;
+import com.linecorp.bot.model.oauth.IssueChannelAccessTokenResponse;
+import com.linecorp.bot.model.objectmapper.ModelObjectMapper;
+
+import lombok.AllArgsConstructor;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+/**
+ * An implementation of {@link LineOAuthClient} that issues or revokes channel access tokens.
+ */
+@AllArgsConstructor
+class LineOAuthClientImpl implements LineOAuthClient {
+    private static final ObjectMapper objectMapper = ModelObjectMapper.createNewObjectMapper();
+
+    private final LineOAuthService service;
+
+    @Override
+    public CompletableFuture<IssueChannelAccessTokenResponse> issueChannelToken(
+            IssueChannelAccessTokenRequest req) {
+        return toFuture(service.issueChannelToken(req.getGrantType(),
+                                                  req.getClientId(),
+                                                  req.getClientSecret()));
+    }
+
+    @Override
+    public CompletableFuture<Void> revokeChannelToken(String accessToken) {
+        return toFuture(service.revokeChannelToken(accessToken));
+    }
+
+    private static <T> CompletableFuture<T> toFuture(Call<T> call) {
+        final CallbackCompletableFuture<T> future = new CallbackCompletableFuture<>();
+        call.enqueue(future);
+        return future;
+    }
+
+    static class CallbackCompletableFuture<T> extends CompletableFuture<T> implements Callback<T> {
+        @Override
+        public void onResponse(final Call<T> call, final Response<T> response) {
+            if (response.isSuccessful()) {
+                complete(response.body());
+                return;
+            }
+            if (response.code() == 400) {
+                try {
+                    completeExceptionally(objectMapper.readValue(response.errorBody().string(),
+                                                                 ChannelAccessTokenException.class));
+                    return;
+                } catch (IOException e) {
+                    completeExceptionally(e);
+                }
+            }
+            completeExceptionally(new ChannelAccessTokenException(response.message()));
+        }
+
+        @Override
+        public void onFailure(final Call<T> call, final Throwable t) {
+            completeExceptionally(new ChannelAccessTokenException(t.getMessage(), t));
+        }
+    }
+}

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineOAuthService.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineOAuthService.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.linecorp.bot.model.oauth.ChannelAccessTokenException;
+import com.linecorp.bot.model.oauth.IssueChannelAccessTokenResponse;
+
+import retrofit2.Call;
+import retrofit2.http.Field;
+import retrofit2.http.FormUrlEncoded;
+import retrofit2.http.POST;
+
+/**
+ * An OAuth client that issues or revokes channel access tokens. See {@link LineOAuthClient} and
+ * <a href="https://developers.line.biz/en/reference/messaging-api/#issue-channel-access-token">document</a>
+ * for detail.
+ */
+interface LineOAuthService {
+    /**
+     * Issues a short-lived channel access token. Up to 30 tokens can be issued. If the maximum is exceeded,
+     * existing channel access tokens are revoked in the order of when they were first issued.
+     * It will return a failed {@link CompletableFuture} with {@link ChannelAccessTokenException} if
+     * it has an error during calling the API.
+     */
+    @FormUrlEncoded
+    @POST("v2/oauth/accessToken")
+    Call<IssueChannelAccessTokenResponse> issueChannelToken(@Field("grant_type") String grantType,
+                                                            @Field("client_id") String clientId,
+                                                            @Field("client_secret") String clientSecret);
+
+    /**
+     * Revokes a channel access token. It will return a failed {@link CompletableFuture} with
+     * {@link ChannelAccessTokenException} if it has an error during calling the API.
+     */
+    @FormUrlEncoded
+    @POST("v2/oauth/revoke")
+    Call<Void> revokeChannelToken(@Field("access_token") String accessToken);
+}

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineOAuthClientTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineOAuthClientTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowableOfType;
+
+import java.util.concurrent.CompletionException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.bot.model.oauth.ChannelAccessTokenException;
+import com.linecorp.bot.model.oauth.IssueChannelAccessTokenRequest;
+import com.linecorp.bot.model.oauth.IssueChannelAccessTokenResponse;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+public class LineOAuthClientTest {
+    static {
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+    }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private MockWebServer mockWebServer;
+    private LineOAuthClient target;
+
+    @Before
+    public void setUp() {
+        mockWebServer = new MockWebServer();
+        final String apiEndPoint = mockWebServer.url("/").toString();
+        target = LineOAuthClient.builder()
+                                .apiEndPoint(apiEndPoint)
+                                .build();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    public void issueToken() throws Exception {
+        final IssueChannelAccessTokenResponse mockResponse =
+                IssueChannelAccessTokenResponse.builder()
+                                               .expiresInSecs(30)
+                                               .accessToken("accessToken")
+                                               .build();
+
+        mockWebServer.enqueue(new MockResponse()
+                                      .setResponseCode(200)
+                                      .setBody(OBJECT_MAPPER.writeValueAsString(mockResponse)));
+
+        // Do
+        final IssueChannelAccessTokenResponse actualResponse =
+                target.issueChannelToken(IssueChannelAccessTokenRequest.builder()
+                                                                       .clientId("clientId")
+                                                                       .clientSecret("clientSecret")
+                                                                       .build())
+                      .join();
+
+        // Verify
+        final RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        assertThat(recordedRequest.getPath())
+                .isEqualTo("/v2/oauth/accessToken");
+        assertThat(recordedRequest.getBody().readUtf8())
+                .isEqualTo("grant_type=client_credentials&client_id=clientId&client_secret=clientSecret");
+        assertThat(actualResponse).isEqualTo(mockResponse);
+    }
+
+    @Test
+    public void issueTokenError() throws Exception {
+        mockWebServer.enqueue(new MockResponse()
+                                      .setResponseCode(400)
+                                      .setBody(OBJECT_MAPPER.writeValueAsString(ImmutableMap.of(
+                                              "error", "error",
+                                              "error_description", "errorDetail"
+                                      ))));
+
+        // Do
+        final CompletionException actualException =
+                catchThrowableOfType(() -> target.issueChannelToken(IssueChannelAccessTokenRequest
+                                                                            .builder()
+                                                                            .clientId("clientId")
+                                                                            .clientSecret("clientSecret")
+                                                                            .build()).join(),
+                                     CompletionException.class);
+
+        // Verify
+        final RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        assertThat(recordedRequest.getPath())
+                .isEqualTo("/v2/oauth/accessToken");
+        assertThat(recordedRequest.getBody().readUtf8())
+                .isEqualTo("grant_type=client_credentials&client_id=clientId&client_secret=clientSecret");
+        assertThat(actualException).hasCauseInstanceOf(ChannelAccessTokenException.class);
+        final ChannelAccessTokenException e = (ChannelAccessTokenException) actualException.getCause();
+        assertThat(e.getError()).isEqualTo("error");
+        assertThat(e.getErrorDescription()).isEqualTo("errorDetail");
+    }
+
+    @Test
+    public void revokeToken() throws Exception {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200));
+
+        // Do
+        target.revokeChannelToken("accessToken").join();
+
+        // Verify
+        final RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        assertThat(recordedRequest.getPath())
+                .isEqualTo("/v2/oauth/revoke");
+        assertThat(recordedRequest.getBody().readUtf8())
+                .isEqualTo("access_token=accessToken");
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/oauth/ChannelAccessTokenException.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/oauth/ChannelAccessTokenException.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.oauth;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * A general {@link Exception} for LINE channel access token API.
+ */
+@Getter
+@ToString
+@SuppressWarnings("serial")
+public class ChannelAccessTokenException extends RuntimeException {
+    /**
+     * An error summary.
+     */
+    private final String error;
+
+    /**
+     * Details of the error. Not returned in certain situations.
+     */
+    private final String errorDescription;
+
+    @JsonCreator
+    public ChannelAccessTokenException(@JsonProperty("error") String error,
+                                       @JsonProperty("error_description") String errorDescription) {
+        this.error = error;
+        this.errorDescription = errorDescription;
+    }
+
+    public ChannelAccessTokenException(String error, String errorDescription, Throwable thrown) {
+        super(error, thrown);
+        this.error = error;
+        this.errorDescription = errorDescription;
+    }
+
+    public ChannelAccessTokenException(String message) {
+        super(message);
+        this.error = message;
+        this.errorDescription = null;
+    }
+
+    public ChannelAccessTokenException(String message, Throwable t) {
+        super(message, t);
+        error = message;
+        this.errorDescription = null;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/oauth/IssueChannelAccessTokenRequest.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/oauth/IssueChannelAccessTokenRequest.java
@@ -23,7 +23,7 @@ import lombok.Value;
 @Builder
 public class IssueChannelAccessTokenRequest {
     /**
-     * Access token gran type.
+     * Access token grant type.
      */
     @Builder.Default
     String grantType = "client_credentials";

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/oauth/IssueChannelAccessTokenRequest.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/oauth/IssueChannelAccessTokenRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.oauth;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class IssueChannelAccessTokenRequest {
+    /**
+     * Access token gran type.
+     */
+    @Builder.Default
+    String grantType = "client_credentials";
+
+    /**
+     * A channel ID. Found on the <a href="https://developers.line.biz/console/">console</a>.
+     */
+    String clientId;
+
+    /**
+     * A channel secret. Found on the <a href="https://developers.line.biz/console/">console</a>.
+     */
+    String clientSecret;
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/oauth/IssueChannelAccessTokenResponse.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/oauth/IssueChannelAccessTokenResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.oauth;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import com.linecorp.bot.model.oauth.IssueChannelAccessTokenResponse.IssueChannelAccessTokenResponseBuilder;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@JsonDeserialize(builder = IssueChannelAccessTokenResponseBuilder.class)
+public class IssueChannelAccessTokenResponse {
+    /**
+     * A short-lived channel access token. Valid for 30 days. Note: Channel access tokens cannot be refreshed.
+     */
+    String accessToken;
+
+    /**
+     * Time until channel access token expires in seconds from time the token is issued.
+     */
+    int expiresInSecs;
+
+    /**
+     * A token type.
+     */
+    @Builder.Default
+    String tokenType = "Bearer";
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class IssueChannelAccessTokenResponseBuilder {
+        // Filled by lombok.
+    }
+}


### PR DESCRIPTION
Changes:
- Adds LineOAuthClient that supports issuing and revoking a LINE channel access token

Results:
- Cloeses #330