### PR TITLE
Add requestId field in BotApiResponse.

### DIFF
--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/BotApiResponseBody.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/BotApiResponseBody.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import static java.util.Collections.emptyList;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import com.linecorp.bot.client.BotApiResponseBody.BotApiResponseBodyBuilder;
+import com.linecorp.bot.model.response.BotApiResponse;
+
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Value;
+
+/**
+ * Response body of BotApiResponse.
+ *
+ * <p>Developer will use {@link BotApiResponse} returned by {@link #withRequestId} method.
+ *
+ * @see BotApiResponse
+ */
+@Value
+@Builder
+@JsonDeserialize(builder = BotApiResponseBodyBuilder.class)
+class BotApiResponseBody {
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class BotApiResponseBodyBuilder {
+        // filled by lombok.
+    }
+
+    String message;
+    @Default
+    List<String> details = emptyList();
+
+    BotApiResponse withRequestId(final String requestId) {
+        return new BotApiResponse(requestId, message, details);
+    }
+}

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingService.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingService.java
@@ -24,7 +24,6 @@ import com.linecorp.bot.model.PushMessage;
 import com.linecorp.bot.model.ReplyMessage;
 import com.linecorp.bot.model.profile.MembersIdsResponse;
 import com.linecorp.bot.model.profile.UserProfileResponse;
-import com.linecorp.bot.model.response.BotApiResponse;
 import com.linecorp.bot.model.response.GetNumberOfFollowersResponse;
 import com.linecorp.bot.model.response.GetNumberOfMessageDeliveriesResponse;
 import com.linecorp.bot.model.response.IssueLinkTokenResponse;
@@ -61,7 +60,7 @@ interface LineMessagingService {
      * @see LineMessagingClient#replyMessage(ReplyMessage)
      */
     @POST("v2/bot/message/reply")
-    Call<BotApiResponse> replyMessage(@Body ReplyMessage replyMessage);
+    Call<BotApiResponseBody> replyMessage(@Body ReplyMessage replyMessage);
 
     /**
      * Method for Retrofit.
@@ -69,7 +68,7 @@ interface LineMessagingService {
      * @see LineMessagingClient#pushMessage(PushMessage)
      */
     @POST("v2/bot/message/push")
-    Call<BotApiResponse> pushMessage(@Body PushMessage pushMessage);
+    Call<BotApiResponseBody> pushMessage(@Body PushMessage pushMessage);
 
     /**
      * Method for Retrofit.
@@ -77,13 +76,13 @@ interface LineMessagingService {
      * @see LineMessagingClient#multicast(Multicast)
      */
     @POST("v2/bot/message/multicast")
-    Call<BotApiResponse> multicast(@Body Multicast multicast);
+    Call<BotApiResponseBody> multicast(@Body Multicast multicast);
 
     /**
      * Sends push messages to multiple users at any time.
      */
     @POST("v2/bot/message/broadcast")
-    Call<BotApiResponse> broadcast(@Body Broadcast broadcast);
+    Call<BotApiResponseBody> broadcast(@Body Broadcast broadcast);
 
     /**
      * Method for Retrofit.
@@ -196,7 +195,7 @@ interface LineMessagingService {
      * @see LineMessagingClient#leaveGroup(String)
      */
     @POST("v2/bot/group/{groupId}/leave")
-    Call<BotApiResponse> leaveGroup(@Path("groupId") String groupId);
+    Call<BotApiResponseBody> leaveGroup(@Path("groupId") String groupId);
 
     /**
      * Method for Retrofit.
@@ -204,7 +203,7 @@ interface LineMessagingService {
      * @see LineMessagingClient#leaveRoom(String)
      */
     @POST("v2/bot/room/{roomId}/leave")
-    Call<BotApiResponse> leaveRoom(@Path("roomId") String roomId);
+    Call<BotApiResponseBody> leaveRoom(@Path("roomId") String roomId);
 
     /**
      * Method for Retrofit.

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplRichMenuWiremockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplRichMenuWiremockTest.java
@@ -26,12 +26,14 @@ import com.linecorp.bot.model.response.BotApiResponse;
 import okhttp3.mockwebserver.MockResponse;
 
 public class LineMessagingClientImplRichMenuWiremockTest extends AbstractWiremockTest {
-    public static final BotApiResponse SUCCESS = new BotApiResponse("", emptyList());
+    public static final BotApiResponseBody SUCCESS_BODY = new BotApiResponseBody("", emptyList());
+    public static final BotApiResponse SUCCESS = SUCCESS_BODY.withRequestId("REQUEST_ID");
 
     @Test(timeout = ASYNC_TEST_TIMEOUT)
     public void status200WithoutBodyTest() throws Exception {
         // Mocking
-        mockWebServer.enqueue(new MockResponse().setResponseCode(200));
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+                                                .addHeader("x-line-request-id", "REQUEST_ID"));
 
         // Do
         final BotApiResponse botApiResponse = lineMessagingClient.deleteRichMenu("RICH_MENU_ID").get();
@@ -41,7 +43,9 @@ public class LineMessagingClientImplRichMenuWiremockTest extends AbstractWiremoc
     @Test(timeout = ASYNC_TEST_TIMEOUT)
     public void status200WithBodyTest() throws Exception {
         // Mocking
-        mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+                                                .addHeader("x-line-request-id", "REQUEST_ID")
+                                                .setBody("{}"));
 
         // Do
         final BotApiResponse botApiResponse = lineMessagingClient.deleteRichMenu("RICH_MENU_ID").get();

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/response/BotApiResponse.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/response/BotApiResponse.java
@@ -16,10 +16,7 @@
 
 package com.linecorp.bot.model.response;
 
-import java.util.Collections;
 import java.util.List;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Value;
 
@@ -28,14 +25,10 @@ import lombok.Value;
  */
 @Value
 public class BotApiResponse {
+    /**
+     * Value from {@literal X-Line-Request-Id} header.
+     */
+    private final String requestId;
     private final String message;
     private final List<String> details;
-
-    public BotApiResponse(
-            @JsonProperty("message") String message,
-            @JsonProperty("details") List<String> details
-    ) {
-        this.message = message;
-        this.details = details == null ? Collections.emptyList() : details;
-    }
 }

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/support/ReplyByReturnValueConsumerTest.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/support/ReplyByReturnValueConsumerTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.bot.spring.boot.support;
 
 import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.only;
@@ -69,7 +70,7 @@ public class ReplyByReturnValueConsumerTest {
     public void setUp() {
         target = targetFactory.createForEvent(EVENT);
         when(lineMessagingClient.replyMessage(any()))
-                .thenReturn(CompletableFuture.completedFuture(new BotApiResponse("success", null)));
+                .thenReturn(completedFuture(new BotApiResponse("", " success", null)));
     }
 
     // Publich methods test


### PR DESCRIPTION
Add requestId field. And fill field value based on response header value.

Only `LineMessagingService.java` is changed. And `LineMessagingClient` has no effect.

This PR closes https://github.com/line/line-bot-sdk-java/issues/387.