### PR TITLE
Add GitHub actions build. (Include JDK11 support)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,5 @@
 codecov:
+  token: 3144ee37-e0d1-4153-ba55-b0ef4ec8c416 # Needed when execute by GitHub Actions. (Safe to published)
   notify:
     require_ci_to_pass: no
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,86 @@
+# Definition of GitHub Actions.
+# Designed to working both LINE's and forked repository.
+#
+# Note:
+#  Memory:
+#    VM Spec = 2core, 7G RAM. as of 2019-10. https://help.github.com/en/github/automating-your-workflow-with-github-actions/virtual-environments-for-github-actions
+#    There are possiblity that speed up build by setting xmx manually. But using default now.
+#  Gradle Deamon:
+#    Disabled via appending ~/.gradle/gradle.properties
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    name: test (JDK ${{ matrix.java }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ '1.8', '11.x' ] # LTS's. (As of 2019-10, Gradle don't support JDK 13.)
+    steps:
+    - name: actions/setup-java@v1 (JDK ${{ matrix.java }})
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+        architecture: x64
+    - uses: actions/checkout@v1
+    - run: |
+        mkdir -p ~/.gradle
+        echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
+    - run: ./gradlew -v
+    - run: ./gradlew check -xcheckstyleMain -xcheckstyleTest -xspotbugsMain -xspotbugsTest
+    # Runs all check and its dependency exept which runs on splitted jobs.
+
+  checkstyle:
+    name: checkstyle
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: actions/setup-java@v1 (JDK 1.8)
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+        architecture: x64
+    - uses: actions/checkout@v1
+    - run: |
+        mkdir -p ~/.gradle
+        echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
+    - run: ./gradlew -v
+    - run: ./gradlew checkstyleMain checkstyleTest --parallel
+
+  spotbugs:
+    name: spotbugs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: actions/setup-java@v1 (JDK 1.8)
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+        architecture: x64
+    - uses: actions/checkout@v1
+    - run: |
+        mkdir -p ~/.gradle
+        echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
+    - run: ./gradlew -v
+    - run: ./gradlew spotbugsMain spotbugsTest --parallel
+
+  codeCoverageReport:
+    name: codeCoverageReport
+    if: startsWith(github.repository, 'line/') # Runs only line/line-bot-sdk-java
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: actions/setup-java@v1 (JDK 1.8)
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+        architecture: x64
+    - uses: actions/checkout@v1
+    - run: |
+        mkdir -p ~/.gradle
+        echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
+    - run: ./gradlew -v
+    - run: ./gradlew test codeCoverageReport
+    - run:  bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Add GitHub Actions.
This includes matrix build on JDK8 and JDK11.
Only test tasks execute both JDK.

GitHub actions supports 10 concurrent job execution.
Spotbugs, checkstyle and code coverage runs only JDK8 due to those are independent with JDK version.

As a result. Build time will be a little shorter than current build workflow.

This closes https://github.com/line/line-bot-sdk-java/issues/391.

AS-IS 
-----
~ 5 min for every build.
![image](https://user-images.githubusercontent.com/1370068/67632453-c2731800-f8e6-11e9-9aa0-4f9c25d1843a.png)


TO-BE
-----
~ 3.x min for every build.
![image](https://user-images.githubusercontent.com/1370068/67632468-f6e6d400-f8e6-11e9-8320-21f7ce611406.png)

