### PR TITLE
Revert "Remove travis CI."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: java
+sudo: false
+jdk:
+  - openjdk8
+script:
+  - ./gradlew check
+  - ./gradlew codeCoverageReport
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LINE Messaging API SDK for Java
 
-[![Build Status](https://github.com/line/line-bot-sdk-java/workflows/CI/badge.svg?event%3Apush+branch%3Amaster)](https://github.com/line/line-bot-sdk-java/actions?query=event%3Apush+branch%3Amaster)
+[![Build Status](https://travis-ci.org/line/line-bot-sdk-java.svg?branch=master)](https://travis-ci.org/line/line-bot-sdk-java)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.linecorp.bot/line-bot-model/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.linecorp.bot/line-bot-model)
 [![javadoc.io](https://javadocio-badges.herokuapp.com/com.linecorp.bot/line-bot-model/badge.svg)](https://javadocio-badges.herokuapp.com/com.linecorp.bot/line-bot-model)
 [![codecov](https://codecov.io/gh/line/line-bot-sdk-java/branch/master/graph/badge.svg)](https://codecov.io/gh/line/line-bot-sdk-java)


### PR DESCRIPTION
Reverts line/line-bot-sdk-java#394 due to GitHub's Action is not working now.