### PR TITLE
generate spring-configuration-metadata.json by spring-boot-configuration-processor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ subprojects {
     }
 
     dependencies {
-        compileOnly 'org.springframework.boot:spring-boot-configuration-processor'
+        annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
         // http://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html#configuration-metadata-annotation-processor
 
         testCompile 'com.google.guava:guava'


### PR DESCRIPTION
`annotationProcessor` should be used instead of `compileOnly` on [Gradle 5.6.1](https://github.com/line/line-bot-sdk-java/blob/3.1.0/gradle/wrapper/gradle-wrapper.properties#L3).

[Spring Boot reference](https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-configuration-metadata.html#configuration-metadata-annotation-processor) says:
> With Gradle 4.6 and later, the dependency should be declared in the annotationProcessor configuration, as shown in the following example:
> ```
> dependencies {
>     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
> }
> ```