### PR TITLE
ISSUE-341 Support Line Things Scenario Result Event

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/LinkThingsContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/LinkThingsContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2019 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,23 +16,19 @@
 
 package com.linecorp.bot.model.event.things;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 
-@JsonSubTypes({
-        @JsonSubTypes.Type(LinkThingsContent.class),
-        @JsonSubTypes.Type(UnlinkThingsContent.class),
-        @JsonSubTypes.Type(ScenarioResultThingsContent.class),
-})
-@JsonTypeInfo(
-        use = JsonTypeInfo.Id.NAME,
-        property = "type",
-        defaultImpl = UnknownLineThingsContent.class,
-        visible = true
-)
-public interface ThingsContent {
-    /**
-     * The id that LINE Things issues.
-     */
-    String getDeviceId();
+import lombok.Value;
+
+@Value
+@JsonTypeName("link")
+public class LinkThingsContent implements ThingsContent {
+    private final String deviceId;
+
+    @JsonCreator
+    public LinkThingsContent(@JsonProperty("deviceId") final String deviceId) {
+        this.deviceId = deviceId;
+    }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/ScenarioResultThingsContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/ScenarioResultThingsContent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.event.things;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import com.linecorp.bot.model.event.things.result.ScenarioResult;
+
+import lombok.Value;
+
+@Value
+@JsonTypeName("scenarioResult")
+public class ScenarioResultThingsContent implements ThingsContent {
+    private final String deviceId;
+    private final ScenarioResult result;
+
+    @JsonCreator
+    public ScenarioResultThingsContent(
+            @JsonProperty("deviceId") String deviceId,
+            @JsonProperty("result") ScenarioResult result
+    ) {
+        this.deviceId = deviceId;
+        this.result = result;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/UnknownLineThingsContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/UnknownLineThingsContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2019 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,23 +16,12 @@
 
 package com.linecorp.bot.model.event.things;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
-@JsonSubTypes({
-        @JsonSubTypes.Type(LinkThingsContent.class),
-        @JsonSubTypes.Type(UnlinkThingsContent.class),
-        @JsonSubTypes.Type(ScenarioResultThingsContent.class),
-})
-@JsonTypeInfo(
-        use = JsonTypeInfo.Id.NAME,
-        property = "type",
-        defaultImpl = UnknownLineThingsContent.class,
-        visible = true
-)
-public interface ThingsContent {
-    /**
-     * The id that LINE Things issues.
-     */
-    String getDeviceId();
+/**
+ * Fallback for {@link ThingsContent}.
+ */
+public class UnknownLineThingsContent implements ThingsContent {
+    @Override
+    public String getDeviceId() {
+        return null;
+    }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/UnlinkThingsContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/UnlinkThingsContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2019 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,23 +16,19 @@
 
 package com.linecorp.bot.model.event.things;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 
-@JsonSubTypes({
-        @JsonSubTypes.Type(LinkThingsContent.class),
-        @JsonSubTypes.Type(UnlinkThingsContent.class),
-        @JsonSubTypes.Type(ScenarioResultThingsContent.class),
-})
-@JsonTypeInfo(
-        use = JsonTypeInfo.Id.NAME,
-        property = "type",
-        defaultImpl = UnknownLineThingsContent.class,
-        visible = true
-)
-public interface ThingsContent {
-    /**
-     * The id that LINE Things issues.
-     */
-    String getDeviceId();
+import lombok.Value;
+
+@Value
+@JsonTypeName("unlink")
+public class UnlinkThingsContent implements ThingsContent {
+    private final String deviceId;
+
+    @JsonCreator
+    public UnlinkThingsContent(@JsonProperty("deviceId") final String deviceId) {
+        this.deviceId = deviceId;
+    }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/ActionResult.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/ActionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2019 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -14,25 +14,20 @@
  * under the License.
  */
 
-package com.linecorp.bot.model.event.things;
+package com.linecorp.bot.model.event.things.result;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonSubTypes({
-        @JsonSubTypes.Type(LinkThingsContent.class),
-        @JsonSubTypes.Type(UnlinkThingsContent.class),
-        @JsonSubTypes.Type(ScenarioResultThingsContent.class),
+        @JsonSubTypes.Type(VoidActionResult.class),
+        @JsonSubTypes.Type(BinaryActionResult.class),
+        @JsonSubTypes.Type(UnknownActionResult.class),
 })
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
         property = "type",
-        defaultImpl = UnknownLineThingsContent.class,
+        defaultImpl = UnknownActionResult.class,
         visible = true
 )
-public interface ThingsContent {
-    /**
-     * The id that LINE Things issues.
-     */
-    String getDeviceId();
-}
+public interface ActionResult {}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/BinaryActionResult.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/BinaryActionResult.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.event.things.result;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import lombok.Value;
+
+@Value
+@JsonTypeName("binary")
+public class BinaryActionResult implements ActionResult {
+    private final String data;
+
+    @JsonCreator
+    public BinaryActionResult(@JsonProperty("data") final String data) {
+        this.data = data;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/ScenarioResult.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/ScenarioResult.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.event.things.result;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Value;
+
+@Value
+public class ScenarioResult {
+    private final String scenarioId;
+    private final long revision;
+    private final Instant startTime;
+    private final Instant endTime;
+    private final String resultCode;
+    private final List<ActionResult> actionResults;
+    private final String bleNotificationPayload;
+    private final String errorReason;
+
+    @JsonCreator
+    ScenarioResult(
+            @JsonProperty("scenarioId") String scenarioId,
+            @JsonProperty("revision") long revision,
+            @JsonProperty("startTime") Instant startTime,
+            @JsonProperty("endTime") Instant endTime,
+            @JsonProperty("resultCode") String resultCode,
+            @JsonProperty("actionResults") List<ActionResult> actionResults,
+            @JsonProperty("bleNotificationPayload") String bleNotificationPayload,
+            @JsonProperty("errorReason") String errorReason
+    ) {
+        this.scenarioId = scenarioId;
+        this.revision = revision;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.resultCode = resultCode;
+        this.actionResults = actionResults;
+        this.bleNotificationPayload = bleNotificationPayload;
+        this.errorReason = errorReason;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/UnknownActionResult.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/UnknownActionResult.java
@@ -16,4 +16,5 @@
 
 package com.linecorp.bot.model.event.things.result;
 
-public class UnknownActionResult implements ActionResult {}
+public class UnknownActionResult implements ActionResult {
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/UnknownActionResult.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/UnknownActionResult.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.event.things.result;
+
+public class UnknownActionResult implements ActionResult {}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/VoidActionResult.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/VoidActionResult.java
@@ -19,4 +19,5 @@ package com.linecorp.bot.model.event.things.result;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("void")
-public class VoidActionResult implements ActionResult {}
+public class VoidActionResult implements ActionResult {
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/VoidActionResult.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/things/result/VoidActionResult.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.model.event.things.result;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeName("void")
+public class VoidActionResult implements ActionResult {}

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
@@ -45,9 +45,11 @@ import com.linecorp.bot.model.event.source.UnknownSource;
 import com.linecorp.bot.model.event.source.UserSource;
 import com.linecorp.bot.model.event.things.LinkThingsContent;
 import com.linecorp.bot.model.event.things.ScenarioResultThingsContent;
+import com.linecorp.bot.model.event.things.UnknownLineThingsContent;
 import com.linecorp.bot.model.event.things.UnlinkThingsContent;
 import com.linecorp.bot.model.event.things.result.BinaryActionResult;
 import com.linecorp.bot.model.event.things.result.ScenarioResult;
+import com.linecorp.bot.model.event.things.result.VoidActionResult;
 import com.linecorp.bot.model.testutil.TestUtil;
 
 public class CallbackRequestTest {
@@ -428,8 +430,23 @@ public class CallbackRequestTest {
             assertThat(result.getEndTime()).isEqualTo(Instant.ofEpochMilli(1547817845952L));
             assertThat(result.getResultCode()).isEqualTo("success");
             assertThat(result.getActionResults().get(0)).isEqualTo(new BinaryActionResult("/w=="));
+            assertThat(result.getActionResults().get(1)).isInstanceOf(VoidActionResult.class);
             assertThat(result.getBleNotificationPayload()).isEqualTo("AQ==");
             assertThat(result.getErrorReason()).isEqualTo(null);
+        });
+    }
+
+    @Test
+    public void testLineThingsUnknown() throws IOException {
+        parse("callback/line-things-unknown.json", callbackRequest -> {
+            assertThat(callbackRequest.getEvents()).hasSize(1);
+            final ThingsEvent event = (ThingsEvent) callbackRequest.getEvents().get(0);
+            assertThat(event).isInstanceOf(ThingsEvent.class);
+            assertThat(event.getSource()).isInstanceOf(UserSource.class);
+            assertThat(event.getSource().getUserId()).isEqualTo("U012345678901234567890123456789ab");
+            assertThat(event.getTimestamp()).isEqualTo(Instant.ofEpochMilli(1462629479859L));
+
+            assertThat(event.getThings()).isInstanceOf(UnknownLineThingsContent.class);
         });
     }
 

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
@@ -49,6 +49,7 @@ import com.linecorp.bot.model.event.things.UnknownLineThingsContent;
 import com.linecorp.bot.model.event.things.UnlinkThingsContent;
 import com.linecorp.bot.model.event.things.result.BinaryActionResult;
 import com.linecorp.bot.model.event.things.result.ScenarioResult;
+import com.linecorp.bot.model.event.things.result.UnknownActionResult;
 import com.linecorp.bot.model.event.things.result.VoidActionResult;
 import com.linecorp.bot.model.testutil.TestUtil;
 
@@ -431,6 +432,7 @@ public class CallbackRequestTest {
             assertThat(result.getResultCode()).isEqualTo("success");
             assertThat(result.getActionResults().get(0)).isEqualTo(new BinaryActionResult("/w=="));
             assertThat(result.getActionResults().get(1)).isInstanceOf(VoidActionResult.class);
+            assertThat(result.getActionResults().get(2)).isInstanceOf(UnknownActionResult.class);
             assertThat(result.getBleNotificationPayload()).isEqualTo("AQ==");
             assertThat(result.getErrorReason()).isEqualTo(null);
         });

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
@@ -43,10 +43,15 @@ import com.linecorp.bot.model.event.source.GroupSource;
 import com.linecorp.bot.model.event.source.Source;
 import com.linecorp.bot.model.event.source.UnknownSource;
 import com.linecorp.bot.model.event.source.UserSource;
-import com.linecorp.bot.model.event.things.ThingsContent;
+import com.linecorp.bot.model.event.things.LinkThingsContent;
+import com.linecorp.bot.model.event.things.ScenarioResultThingsContent;
+import com.linecorp.bot.model.event.things.UnlinkThingsContent;
+import com.linecorp.bot.model.event.things.result.BinaryActionResult;
+import com.linecorp.bot.model.event.things.result.ScenarioResult;
 import com.linecorp.bot.model.testutil.TestUtil;
 
 public class CallbackRequestTest {
+    @FunctionalInterface
     interface RequestTester {
         void call(CallbackRequest request) throws IOException;
     }
@@ -377,20 +382,14 @@ public class CallbackRequestTest {
     public void testLineThingsLink() throws IOException {
         parse("callback/line-things-link.json", callbackRequest -> {
             assertThat(callbackRequest.getEvents()).hasSize(1);
-            Event event = callbackRequest.getEvents().get(0);
+            final ThingsEvent event = (ThingsEvent) callbackRequest.getEvents().get(0);
             assertThat(event).isInstanceOf(ThingsEvent.class);
-            assertThat(event.getSource())
-                    .isInstanceOf(UserSource.class);
-            assertThat(event.getSource().getUserId())
-                    .isEqualTo("U012345678901234567890123456789ab");
-            assertThat(event.getTimestamp())
-                    .isEqualTo(Instant.parse("2016-05-07T13:57:59.859Z"));
+            assertThat(event.getSource()).isInstanceOf(UserSource.class);
+            assertThat(event.getSource().getUserId()).isEqualTo("U012345678901234567890123456789ab");
+            assertThat(event.getTimestamp()).isEqualTo(Instant.parse("2016-05-07T13:57:59.859Z"));
 
-            ThingsEvent thingsEvent = (ThingsEvent) event;
-            assertThat(thingsEvent.getThings().getDeviceId())
-                    .isEqualTo("t016560bc3fb1e42b9fe9293ca6e2db71");
-            assertThat(thingsEvent.getThings().getType())
-                    .isEqualTo(ThingsContent.ThingsType.LINK);
+            final LinkThingsContent things = (LinkThingsContent) event.getThings();
+            assertThat(things.getDeviceId()).isEqualTo("t016560bc3fb1e42b9fe9293ca6e2db71");
         });
     }
 
@@ -398,20 +397,39 @@ public class CallbackRequestTest {
     public void testLineThingsUnlink() throws IOException {
         parse("callback/line-things-unlink.json", callbackRequest -> {
             assertThat(callbackRequest.getEvents()).hasSize(1);
-            Event event = callbackRequest.getEvents().get(0);
+            final ThingsEvent event = (ThingsEvent) callbackRequest.getEvents().get(0);
             assertThat(event).isInstanceOf(ThingsEvent.class);
-            assertThat(event.getSource())
-                    .isInstanceOf(UserSource.class);
-            assertThat(event.getSource().getUserId())
-                    .isEqualTo("U012345678901234567890123456789ab");
-            assertThat(event.getTimestamp())
-                    .isEqualTo(Instant.parse("2016-05-07T13:57:59.859Z"));
+            assertThat(event.getSource()).isInstanceOf(UserSource.class);
+            assertThat(event.getSource().getUserId()).isEqualTo("U012345678901234567890123456789ab");
+            assertThat(event.getTimestamp()).isEqualTo(Instant.ofEpochMilli(1462629479859L));
 
-            ThingsEvent thingsEvent = (ThingsEvent) event;
-            assertThat(thingsEvent.getThings().getDeviceId())
-                    .isEqualTo("t016560bc3fb1e42b9fe9293ca6e2db71");
-            assertThat(thingsEvent.getThings().getType())
-                    .isEqualTo(ThingsContent.ThingsType.UNLINK);
+            final UnlinkThingsContent things = (UnlinkThingsContent) event.getThings();
+            assertThat(things.getDeviceId()).isEqualTo("t016560bc3fb1e42b9fe9293ca6e2db71");
+        });
+    }
+
+    @Test
+    public void testLineThingsScenarioResult() throws IOException {
+        parse("callback/line-things-scenario-result.json", callbackRequest -> {
+            assertThat(callbackRequest.getEvents()).hasSize(1);
+            final ThingsEvent event = (ThingsEvent) callbackRequest.getEvents().get(0);
+            assertThat(event).isInstanceOf(ThingsEvent.class);
+            assertThat(event.getSource()).isInstanceOf(UserSource.class);
+            assertThat(event.getSource().getUserId()).isEqualTo("uXXX");
+            assertThat(event.getTimestamp()).isEqualTo(Instant.ofEpochMilli(1547817848122L));
+
+            final ScenarioResultThingsContent things = (ScenarioResultThingsContent) event.getThings();
+            assertThat(things.getDeviceId()).isEqualTo("tXXX");
+
+            final ScenarioResult result = things.getResult();
+            assertThat(result.getScenarioId()).isEqualTo("XXX");
+            assertThat(result.getRevision()).isEqualTo(2);
+            assertThat(result.getStartTime()).isEqualTo(Instant.ofEpochMilli(1547817845950L));
+            assertThat(result.getEndTime()).isEqualTo(Instant.ofEpochMilli(1547817845952L));
+            assertThat(result.getResultCode()).isEqualTo("success");
+            assertThat(result.getActionResults().get(0)).isEqualTo(new BinaryActionResult("/w=="));
+            assertThat(result.getBleNotificationPayload()).isEqualTo("AQ==");
+            assertThat(result.getErrorReason()).isEqualTo(null);
         });
     }
 
@@ -424,8 +442,8 @@ public class CallbackRequestTest {
             assertThat(event).isInstanceOf(MemberJoinedEvent.class);
             MemberJoinedEvent memberJoinedEvent = (MemberJoinedEvent) event;
             String uids = memberJoinedEvent.getJoined().getMembers().stream()
-                    .map(Source::getUserId)
-                    .collect(Collectors.joining(","));
+                                           .map(Source::getUserId)
+                                           .collect(Collectors.joining(","));
             assertThat(uids).isEqualTo("U111111");
         });
     }
@@ -439,8 +457,8 @@ public class CallbackRequestTest {
             assertThat(event).isInstanceOf(MemberLeftEvent.class);
             MemberLeftEvent memberLeftEvent = (MemberLeftEvent) event;
             String uids = memberLeftEvent.getLeft().getMembers().stream()
-                    .map(Source::getUserId)
-                    .collect(Collectors.joining(","));
+                                         .map(Source::getUserId)
+                                         .collect(Collectors.joining(","));
             assertThat(uids).isEqualTo("U111111");
         });
     }

--- a/line-bot-model/src/test/resources/callback/line-things-scenario-result.json
+++ b/line-bot-model/src/test/resources/callback/line-things-scenario-result.json
@@ -1,0 +1,32 @@
+{
+  "events": [
+    {
+      "type": "things",
+      "replyToken": "0f3779fba3b349968c5d07db31eab56f",
+      "source": {
+        "userId": "uXXX",
+        "type": "user"
+      },
+      "timestamp": 1547817848122,
+      "things": {
+        "type": "scenarioResult",
+        "deviceId": "tXXX",
+        "result": {
+          "scenarioId": "XXX",
+          "revision": 2,
+          "startTime": 1547817845950,
+          "endTime": 1547817845952,
+          "resultCode": "success",
+          "bleNotificationPayload": "AQ==",
+          "actionResults": [
+            {
+              "type": "binary",
+              "data": "/w=="
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "destination": "uXXX"
+}

--- a/line-bot-model/src/test/resources/callback/line-things-scenario-result.json
+++ b/line-bot-model/src/test/resources/callback/line-things-scenario-result.json
@@ -22,6 +22,9 @@
             {
               "type": "binary",
               "data": "/w=="
+            },
+            {
+              "type": "void"
             }
           ]
         }

--- a/line-bot-model/src/test/resources/callback/line-things-scenario-result.json
+++ b/line-bot-model/src/test/resources/callback/line-things-scenario-result.json
@@ -25,6 +25,10 @@
             },
             {
               "type": "void"
+            },
+            {
+              "type": "unknowType",
+              "unknowProperty": "fuga"
             }
           ]
         }

--- a/line-bot-model/src/test/resources/callback/line-things-unknown.json
+++ b/line-bot-model/src/test/resources/callback/line-things-unknown.json
@@ -1,0 +1,17 @@
+{
+  "events": [
+    {
+      "replyToken": "nHuyWiB7yP5Zw52FIkcQobQuGDXCTA",
+      "type": "things",
+      "timestamp": 1462629479859,
+      "source": {
+        "type": "user",
+        "userId": "U012345678901234567890123456789ab"
+      },
+      "things": {
+        "unknownProperty": "hogeHuga",
+        "type": "unknownLineThingsEvent"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
#341

Note:
Using enum class `ThingsType` as things type is a little problem. This PR removes enum class `ThingsType`, and prepares a fallback type.