### PR TITLE
Support notificationDisabled option for Multicast, PushMessage, ReplyMessage

### DIFF
--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplTest.java
@@ -132,7 +132,7 @@ public class LineMessagingClientImplTest {
     @Test
     public void broadcast() {
         whenCall(retrofitMock.broadcast(any()), BOT_API_SUCCESS_RESPONSE);
-        final Broadcast broadcast = new Broadcast(Collections.singletonList(new TextMessage("text")), true);
+        final Broadcast broadcast = new Broadcast(Collections.singletonList(new TextMessage("text")));
 
         final BotApiResponse botApiResponse = target.broadcast(broadcast).join();
         verify(retrofitMock).broadcast(broadcast);

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplTest.java
@@ -18,6 +18,7 @@ package com.linecorp.bot.client;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -132,7 +133,7 @@ public class LineMessagingClientImplTest {
     @Test
     public void broadcast() {
         whenCall(retrofitMock.broadcast(any()), BOT_API_SUCCESS_RESPONSE);
-        final Broadcast broadcast = new Broadcast(Collections.singletonList(new TextMessage("text")));
+        final Broadcast broadcast = new Broadcast(singletonList(new TextMessage("text")));
 
         final BotApiResponse botApiResponse = target.broadcast(broadcast).join();
         verify(retrofitMock).broadcast(broadcast);
@@ -387,7 +388,7 @@ public class LineMessagingClientImplTest {
         whenCall(retrofitMock.linkRichMenuToUsers(any()), null);
 
         // Do
-        final BotApiResponse botApiResponse = target.linkRichMenuIdToUsers(Collections.singletonList("USER_ID"),
+        final BotApiResponse botApiResponse = target.linkRichMenuIdToUsers(singletonList("USER_ID"),
                                                                            "RICH_MENU_ID")
                                                     .join();
 
@@ -418,7 +419,7 @@ public class LineMessagingClientImplTest {
                  null);
 
         // Do
-        final BotApiResponse botApiResponse = target.unlinkRichMenuIdFromUsers(Collections.singletonList("ID"))
+        final BotApiResponse botApiResponse = target.unlinkRichMenuIdFromUsers(singletonList("ID"))
                                                     .join();
 
         // Verify

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/Broadcast.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/Broadcast.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.bot.model;
 
+import static java.util.Collections.singletonList;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -48,7 +50,7 @@ public class Broadcast {
     private final boolean notificationDisabled;
 
     public Broadcast(Message messages) {
-        this(Collections.singletonList(messages), false);
+        this(singletonList(messages), false);
     }
 
     public Broadcast(List<Message> messages) {
@@ -56,7 +58,7 @@ public class Broadcast {
     }
 
     public Broadcast(Message messages, boolean notificationDisabled) {
-        this(Collections.singletonList(messages), notificationDisabled);
+        this(singletonList(messages), notificationDisabled);
     }
 
     @JsonCreator

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/Broadcast.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/Broadcast.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.bot.model;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -46,8 +47,16 @@ public class Broadcast {
      */
     private final boolean notificationDisabled;
 
+    public Broadcast(Message messages) {
+        this(Collections.singletonList(messages), false);
+    }
+
     public Broadcast(List<Message> messages) {
         this(messages, false);
+    }
+
+    public Broadcast(Message messages, boolean notificationDisabled) {
+        this(Collections.singletonList(messages), notificationDisabled);
     }
 
     @JsonCreator

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/Broadcast.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/Broadcast.java
@@ -46,6 +46,10 @@ public class Broadcast {
      */
     private final boolean notificationDisabled;
 
+    public Broadcast(List<Message> messages) {
+        this(messages, false);
+    }
+
     @JsonCreator
     public Broadcast(@JsonProperty("messages") List<Message> messages,
                      @JsonProperty("notificationDisabled") boolean notificationDisabled) {

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/Multicast.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/Multicast.java
@@ -48,15 +48,36 @@ public class Multicast {
      */
     private final List<Message> messages;
 
+    /**
+     * Whether sends a push notification to message receivers or not. If {@literal true}, the user doesn't
+     * receive a push notification when the message is sent. And if {@literal false}, the user receives a push
+     * notification when the message is sent (unless they have disabled push notifications in LINE and/or their
+     * device).
+     */
+    private final boolean notificationDisabled;
+
     public Multicast(final Set<String> to,
                      final Message message) {
-        this(to, Collections.singletonList(message));
+        this(to, Collections.singletonList(message), false);
+    }
+
+    public Multicast(final Set<String> to,
+                     final List<Message> messages) {
+        this(to, messages, false);
+    }
+
+    public Multicast(final Set<String> to,
+                     final Message message,
+                     boolean notificationDisabled) {
+        this(to, Collections.singletonList(message), notificationDisabled);
     }
 
     @JsonCreator
     public Multicast(@JsonProperty("to") final Set<String> to,
-                     @JsonProperty("messages") final List<Message> messages) {
+                     @JsonProperty("messages") final List<Message> messages,
+                     @JsonProperty("notificationDisabled") boolean notificationDisabled) {
         this.to = to;
         this.messages = messages;
+        this.notificationDisabled = notificationDisabled;
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/PushMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/PushMessage.java
@@ -42,8 +42,23 @@ public class PushMessage {
      */
     private final List<Message> messages;
 
+    /**
+     * Whether sends a push notification to message receivers or not. If {@literal true}, the user doesn't
+     * receive a push notification when the message is sent. And if {@literal false}, the user receives a push
+     * notification when the message is sent (unless they have disabled push notifications in LINE and/or their
+     * device).
+     */
+    private final boolean notificationDisabled;
+
     public PushMessage(String to, Message message) {
-        this.to = to;
-        this.messages = Collections.singletonList(message);
+        this(to, Collections.singletonList(message), false);
+    }
+
+    public PushMessage(String to, List<Message> messages) {
+        this(to, messages, false);
+    }
+
+    public PushMessage(String to, Message message, boolean notificationDisabled) {
+        this(to, Collections.singletonList(message), notificationDisabled);
     }
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/ReplyMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/ReplyMessage.java
@@ -49,7 +49,23 @@ public class ReplyMessage {
      */
     private final List<Message> messages;
 
+    /**
+     * Whether sends a push notification to message receivers or not. If {@literal true}, the user doesn't
+     * receive a push notification when the message is sent. And if {@literal false}, the user receives a push
+     * notification when the message is sent (unless they have disabled push notifications in LINE and/or their
+     * device).
+     */
+    private final boolean notificationDisabled;
+
     public ReplyMessage(String replyToken, Message message) {
-        this(replyToken, Collections.singletonList(message));
+        this(replyToken, Collections.singletonList(message), false);
+    }
+
+    public ReplyMessage(String replyToken, List<Message> messages) {
+        this(replyToken, messages, false);
+    }
+
+    public ReplyMessage(String replyToken, Message message, boolean notificationDisabled) {
+        this(replyToken, Collections.singletonList(message), notificationDisabled);
     }
 }

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/message/MessageJsonReconstructionTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/message/MessageJsonReconstructionTest.java
@@ -181,9 +181,11 @@ public class MessageJsonReconstructionTest {
     @Test
     public void multicastTest() {
         final Multicast multicast =
-                new Multicast(singleton("LINE_ID"), singletonList(new TextMessage("text")));
-
+                new Multicast(singleton("LINE_ID"), singletonList(new TextMessage("text")), true);
         test(multicast);
+
+        final Multicast multicast2 = new Multicast(singleton("LINE_ID"), new TextMessage("text"));
+        test(multicast2);
     }
 
     @Test

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/message/MessageJsonReconstructionTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/message/MessageJsonReconstructionTest.java
@@ -184,15 +184,31 @@ public class MessageJsonReconstructionTest {
                 new Multicast(singleton("LINE_ID"), singletonList(new TextMessage("text")), true);
         test(multicast);
 
-        final Multicast multicast2 = new Multicast(singleton("LINE_ID"), new TextMessage("text"));
+        final Multicast multicast2 =
+                new Multicast(singleton("LINE_ID"), new TextMessage("text"), true);
         test(multicast2);
+
+        final Multicast multicast3 =
+                new Multicast(singleton("LINE_ID"), singletonList(new TextMessage("text")));
+        test(multicast3);
+
+        final Multicast multicast4 = new Multicast(singleton("LINE_ID"), new TextMessage("text"));
+        test(multicast4);
     }
 
     @Test
     public void broadcast() {
-        final Broadcast broadcast = new Broadcast(singletonList(new TextMessage("text")), true);
-
+        final Broadcast broadcast = new Broadcast(new TextMessage("text"));
         test(broadcast);
+
+        final Broadcast broadcast2 = new Broadcast(new TextMessage("text"), true);
+        test(broadcast2);
+
+        final Broadcast broadcast3 = new Broadcast(singletonList(new TextMessage("text")));
+        test(broadcast3);
+
+        final Broadcast broadcast4 = new Broadcast(singletonList(new TextMessage("text")), true);
+        test(broadcast4);
     }
 
     @Test

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/IntegrationTest.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/IntegrationTest.java
@@ -157,7 +157,8 @@ public class IntegrationTest {
         assertThat(request1.getHeader("Authorization")).isEqualTo("Bearer TOKEN");
         assertThat(request1.getBody().readUtf8())
                 .isEqualTo("{\"replyToken\":\"nHuyWiB7yP5Zw52FIkcQobQuGDXCTA\","
-                           + "\"messages\":[{\"type\":\"text\",\"text\":\"Hello, world\"}]}");
+                           + "\"messages\":[{\"type\":\"text\",\"text\":\"Hello, world\"}],"
+                           + "\"notificationDisabled\":false}");
 
         // Test request 2
         RecordedRequest request2 = server.takeRequest(3, TimeUnit.SECONDS);
@@ -165,6 +166,7 @@ public class IntegrationTest {
         assertThat(request2.getHeader("Authorization")).isEqualTo("Bearer TOKEN");
         assertThat(request2.getBody().readUtf8())
                 .isEqualTo("{\"replyToken\":\"nHuyWiB7yP5Zw52FIkcQobQuGDXCTA\","
-                           + "\"messages\":[{\"type\":\"text\",\"text\":\"follow\"}]}");
+                           + "\"messages\":[{\"type\":\"text\",\"text\":\"follow\"}],"
+                           + "\"notificationDisabled\":false}");
     }
 }


### PR DESCRIPTION
Now, it's only `Broadcast` class which has `notificationDisabled` option.
[Messaging API Reference](https://developers.line.biz/en/reference/messaging-api/#send-push-message) says that multicast, push message, reply message also have this option.
Thus, `Multicast`, `PushMessage`, `ReplyMessage` of `line-bot-model` should have this option.

Note:
Since `notificationDisabled` is optional and default value is `false`, we should prepare constructor with default value for `notificationDisabled`.