### PR TITLE
Fix getNumberOfFollowers, getNumberOfMessageDeliveries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ local.properties
 
 # PDT-specific
 .buildpath
+integration_test_settings.yml

--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,7 @@ subprojects {
         testCompile 'org.hibernate.validator:hibernate-validator'
         testCompile 'org.springframework.boot:spring-boot-starter-test' // MockHttpServletRequest
         testCompile 'org.springframework.boot:spring-boot-starter-logging'
+        testCompile 'org.yaml:snakeyaml'
     }
 
     compileJava.dependsOn(processResources)

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClient.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClient.java
@@ -334,7 +334,7 @@ public interface LineMessagingClient {
     /**
      * Gets the number of users who have added the bot on or before a specified date.
      */
-    CompletableFuture<GetNumberOfFollowersResponse> getNumberOfFollowersResponse(String date);
+    CompletableFuture<GetNumberOfFollowersResponse> getNumberOfFollowers(String date);
 
     /**
      * Retrieves the demographic attributes for a bot's friends.

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClientImpl.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClientImpl.java
@@ -254,7 +254,7 @@ public class LineMessagingClientImpl implements LineMessagingClient {
     }
 
     @Override
-    public CompletableFuture<GetNumberOfFollowersResponse> getNumberOfFollowersResponse(String date) {
+    public CompletableFuture<GetNumberOfFollowersResponse> getNumberOfFollowers(String date) {
         return toFuture(retrofitImpl.getNumberOfFollowers(date));
     }
 

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingService.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingService.java
@@ -155,7 +155,7 @@ interface LineMessagingService {
      *             {@literal "20191231"}) and the timezone should be UTC+9.
      */
     @GET("v2/bot/message/delivery/broadcast")
-    Call<NumberOfMessagesResponse> getNumberOfSentBroadcastMessages(String date);
+    Call<NumberOfMessagesResponse> getNumberOfSentBroadcastMessages(@Query("date") String date);
 
     /**
      * Method for Retrofit.
@@ -341,7 +341,7 @@ interface LineMessagingService {
      * @param date Date for which to retrieve number of sent messages. The format should be {@code yyyyMMdd}.
      *             For example: {@literal "20191231"}) and the timezone should be UTC+9.
      */
-    @GET("v2/bot/insight/message/delivery?date={date}")
+    @GET("v2/bot/insight/message/delivery")
     Call<GetNumberOfMessageDeliveriesResponse> getNumberOfMessageDeliveries(@Query("date") String date);
 
     /**
@@ -349,6 +349,6 @@ interface LineMessagingService {
      * @param date Date for which to retrieve the number of followers. The format should be {@code yyyyMMdd}.
      *             For example: {@literal "20191231"}) and the timezone should be UTC+9.
      */
-    @GET("v2/bot/insight/followers?date={date}")
+    @GET("v2/bot/insight/followers")
     Call<GetNumberOfFollowersResponse> getNumberOfFollowers(@Query("date") String date);
 }

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplIntegrationTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplIntegrationTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.client;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.linecorp.bot.model.response.GetNumberOfFollowersResponse;
+import com.linecorp.bot.model.response.GetNumberOfMessageDeliveriesResponse;
+import com.linecorp.bot.model.response.NumberOfMessagesResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Integration test of {@link LineMessagingClient}.
+ *
+ * <p>To run this test, please put config file resources/integration_test_settings.yml.
+ */
+@Slf4j
+public class LineMessagingClientImplIntegrationTest {
+    public static final URL TEST_RESOURCE = ClassLoader.getSystemResource("integration_test_settings.yml");
+    private LineMessagingClient target;
+
+    @Before
+    public void setUp() throws IOException {
+        Assume.assumeTrue(TEST_RESOURCE != null);
+
+        final Map<?, ?> map = new ObjectMapper()
+                .convertValue(new Yaml().load(TEST_RESOURCE.openStream()), Map.class);
+
+        target = LineMessagingClient
+                .builder((String) map.get("token"))
+                .apiEndPoint((String) map.get("endpoint"))
+                .build();
+    }
+
+    @Test
+    public void getNumberOfMessageDeliveries() throws Exception {
+        final GetNumberOfMessageDeliveriesResponse getNumberOfMessageDeliveriesResponse =
+                target.getNumberOfMessageDeliveries("20191231").get();
+
+        log.info(getNumberOfMessageDeliveriesResponse.toString());
+    }
+
+    @Test
+    public void getNumberOfSentBroadcastMessages() throws Exception {
+        final NumberOfMessagesResponse getNumberOfSentBroadcastMessages =
+                target.getNumberOfSentBroadcastMessages("20191231").get();
+
+        log.info(getNumberOfSentBroadcastMessages.toString());
+    }
+
+    @Test
+    public void getNumberOfFollowers() throws Exception {
+        final GetNumberOfFollowersResponse getNumberOfFollowersResponse =
+                target.getNumberOfFollowers("20191231").get();
+
+        log.info(getNumberOfFollowersResponse.toString());
+    }
+}

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplTest.java
@@ -198,44 +198,44 @@ public class LineMessagingClientImplTest {
     @Test
     public void getNumberOfSentReplyMessages() {
         whenCall(retrofitMock.getNumberOfSentReplyMessages(any()),
-                 new NumberOfMessagesResponse(NumberOfMessagesResponse.Status.Ready, 1024));
+                 new NumberOfMessagesResponse(NumberOfMessagesResponse.Status.READY, 1024));
 
         NumberOfMessagesResponse response = target.getNumberOfSentReplyMessages("20181231").join();
         verify(retrofitMock, only()).getNumberOfSentReplyMessages("20181231");
-        assertThat(response.getStatus()).isEqualTo(NumberOfMessagesResponse.Status.Ready);
+        assertThat(response.getStatus()).isEqualTo(NumberOfMessagesResponse.Status.READY);
         assertThat(response.getSuccess()).isEqualTo(1024);
     }
 
     @Test
     public void getNumberOfSentPushMessages() {
         whenCall(retrofitMock.getNumberOfSentPushMessages(any()),
-                 new NumberOfMessagesResponse(NumberOfMessagesResponse.Status.Ready, 1024));
+                 new NumberOfMessagesResponse(NumberOfMessagesResponse.Status.READY, 1024));
 
         NumberOfMessagesResponse response = target.getNumberOfSentPushMessages("20181231").join();
         verify(retrofitMock, only()).getNumberOfSentPushMessages("20181231");
-        assertThat(response.getStatus()).isEqualTo(NumberOfMessagesResponse.Status.Ready);
+        assertThat(response.getStatus()).isEqualTo(NumberOfMessagesResponse.Status.READY);
         assertThat(response.getSuccess()).isEqualTo(1024);
     }
 
     @Test
     public void getNumberOfSentMulticastMessages() {
         whenCall(retrofitMock.getNumberOfSentMulticastMessages(any()),
-                 new NumberOfMessagesResponse(NumberOfMessagesResponse.Status.Ready, 1024));
+                 new NumberOfMessagesResponse(NumberOfMessagesResponse.Status.READY, 1024));
 
         NumberOfMessagesResponse response = target.getNumberOfSentMulticastMessages("20181231").join();
         verify(retrofitMock, only()).getNumberOfSentMulticastMessages("20181231");
-        assertThat(response.getStatus()).isEqualTo(NumberOfMessagesResponse.Status.Ready);
+        assertThat(response.getStatus()).isEqualTo(NumberOfMessagesResponse.Status.READY);
         assertThat(response.getSuccess()).isEqualTo(1024);
     }
 
     @Test
     public void getNumberOfSentBroadcastMessages() {
         whenCall(retrofitMock.getNumberOfSentBroadcastMessages(any()),
-                 new NumberOfMessagesResponse(NumberOfMessagesResponse.Status.Ready, 1024));
+                 new NumberOfMessagesResponse(NumberOfMessagesResponse.Status.READY, 1024));
 
         NumberOfMessagesResponse response = target.getNumberOfSentBroadcastMessages("20181231").join();
         verify(retrofitMock, only()).getNumberOfSentBroadcastMessages("20181231");
-        assertThat(response.getStatus()).isEqualTo(NumberOfMessagesResponse.Status.Ready);
+        assertThat(response.getStatus()).isEqualTo(NumberOfMessagesResponse.Status.READY);
         assertThat(response.getSuccess()).isEqualTo(1024);
     }
 
@@ -527,7 +527,7 @@ public class LineMessagingClientImplTest {
     public void getNumberOfMessageDeliveries() throws Exception {
         final GetNumberOfMessageDeliveriesResponse response = GetNumberOfMessageDeliveriesResponse
                 .builder()
-                .status(GetNumberOfMessageDeliveriesResponse.Status.Ready)
+                .status(GetNumberOfMessageDeliveriesResponse.Status.READY)
                 .apiBroadcast(1L)
                 .build();
         whenCall(retrofitMock.getNumberOfMessageDeliveries(any()), response);
@@ -541,14 +541,14 @@ public class LineMessagingClientImplTest {
     public void getNumberOfFollowers() throws Exception {
         final GetNumberOfFollowersResponse response = GetNumberOfFollowersResponse
                 .builder()
-                .status(GetNumberOfFollowersResponse.Status.Ready)
+                .status(GetNumberOfFollowersResponse.Status.READY)
                 .followers(3L)
                 .targetedReaches(2L)
                 .blocks(1L)
                 .build();
         whenCall(retrofitMock.getNumberOfFollowers(any()), response);
         final GetNumberOfFollowersResponse actual =
-                target.getNumberOfFollowersResponse("20190805").get();
+                target.getNumberOfFollowers("20190805").get();
         verify(retrofitMock, only()).getNumberOfFollowers("20190805");
         assertThat(actual).isEqualTo(response);
     }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/response/GetNumberOfFollowersResponse.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/response/GetNumberOfFollowersResponse.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.bot.model.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -35,17 +36,20 @@ public class GetNumberOfFollowersResponse {
         /**
          * Calculation has finished; the numbers are up-to-date.
          */
-        Ready,
+        @JsonProperty("ready")
+        READY,
         /**
          * We haven't finished calculating the number of sent messages for the specified date. Calculation
          * usually takes about a day. Please try again later.
          */
-        Unready,
+        @JsonProperty("unready")
+        UNREADY,
         /**
          * The specified date is earlier than the date on which we first started calculating followers
          * (November 1, 2016).
          */
-        OutOfService
+        @JsonProperty("out_of_service")
+        OUT_OF_SERVICE
     }
 
     /**

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/response/GetNumberOfMessageDeliveriesResponse.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/response/GetNumberOfMessageDeliveriesResponse.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.bot.model.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -35,17 +36,20 @@ public class GetNumberOfMessageDeliveriesResponse {
         /**
          * Calculation has finished; the numbers are up-to-date.
          */
-        Ready,
+        @JsonProperty("ready")
+        READY,
         /**
          * We haven't finished calculating the number of sent messages for the specified date. Calculation
          * usually takes about a day. Please try again later.
          */
-        Unready,
+        @JsonProperty("unready")
+        UNREADY,
         /**
          * The specified date is earlier than the date on which we first started calculating sent messages
          * (March 1, 2017).
          */
-        OutOfService
+        @JsonProperty("out_of_service")
+        OUT_OF_SERVICE
     }
 
     /**

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/response/NumberOfMessagesResponse.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/response/NumberOfMessagesResponse.java
@@ -17,6 +17,7 @@
 package com.linecorp.bot.model.response;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
 import lombok.Value;
@@ -31,17 +32,20 @@ public class NumberOfMessagesResponse {
         /**
          * You can get the number of messages.
          */
-        Ready,
+        @JsonProperty("ready")
+        READY,
         /**
          * The message counting process for the date specified in {@code date} has not been completed yet.
          * Retry your request later. Normally, the counting process is completed within the next day.
          */
-        Unready,
+        @JsonProperty("unready")
+        UNREADY,
         /**
          * The date specified in date is earlier than March 31, 2018, when the operation of the counting system
          * started.
          */
-        OutOfService
+        @JsonProperty("out_of_service")
+        OUT_OF_SERVICE
     }
 
     Status status;


### PR DESCRIPTION
* Fix enum definition. (lower case wire value)
* rename method s/getNumberOfFollowersResponse/getNumberOfFollowers/;

This pr closes https://github.com/line/line-bot-sdk-java/issues/419 and https://github.com/line/line-bot-sdk-java/issues/420.