### PR TITLE
Brush up release flow and write current version explicitly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,23 @@ See http://semver.org/.
 
 Please check [CONTRIBUTING](CONTRIBUTING.md) before making a contribution.
 
+## Release flow
+
+0. Confirm line-bot-sdk-java version is defined at `./gradle.properties`.
+1. Before release, updates a version property at `gradle.properties` with release version (without `SNAPSHOT`), for example `version=3.2.0`.
+2. Commits `gradle.properties` and make a tag with version that specified at step1.
+    For example,
+    ```sh
+    $ git add gradle.properties
+    $ git commit -m "Release 3.2.0"
+    $ git tag '3.2.0'
+    $ git push upstream
+    ```
+3. Upload the artifacts to the staging repository
+4. Close and release the staging repository at https://oss.sonatype.org/
+5. Update `gradle.properties` to `NEXT.GREAT.VERSION-SNAPSHOT`
+6. `git commit -m 'Start NEXT.GREAT.VERSION(-SNAPSHOT)'` and `git push`.
+7. Announce the release via Twitter.
 
 ## License
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,19 +48,20 @@ apply plugin: 'jacoco'
 apply plugin: 'com.github.ben-manes.versions'
 
 group = 'com.linecorp.bot'
-version = '3.1.0'
 
 //set build variables based on build type (release, continuous integration, development)
 def isDevBuild
 def isReleaseBuild
 def sonatypeRepositoryUrl
 if (hasProperty('release')) {
+    assert !version.endsWith('-SNAPSHOT')
     isReleaseBuild = true
     sonatypeRepositoryUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
 } else if (hasProperty('ci')) {
-    version += '-SNAPSHOT'
+    assert version.endsWith('-SNAPSHOT')
     sonatypeRepositoryUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
 } else {
+    assert version.endsWith('-SNAPSHOT')
     isDevBuild = true
     version += '-SNAPSHOT'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
+# Project configurations
+version=3.2.0-SNAPSHOT
+# Gradle configurations
 org.gradle.warning.mode=all


### PR DESCRIPTION
Current version = `3.2.0-SNAPSHOT`.

Formatted version for review: https://github.com/line/line-bot-sdk-java/blob/kazuki-ma/release_flow/README.md