### PR TITLE
NON-ISSUE Remove deprecated .version use.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ subprojects {
     jar {
         manifest {
             attributes 'Implementation-Title': project.name,
-                'Implementation-Version': version
+                'Implementation-Version': archiveVersion
         }
     }
 


### PR DESCRIPTION
Follow following warn.

```
The AbstractArchiveTask.version property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the archiveVersion property instead. See https://docs.gradle.org/6.2.1/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:version for more details.
        at build_5hsvdzfhp8obnj4emhy3khp5l$_run_closure2$_closure9$_closure28.doCall(/Users/kazuki-ma/dev/src/github.com/line/line-bot-sdk-java/build.gradle:146)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```