### PR TITLE
Change type of URL field to `URI` 

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/VideoMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/VideoMessageContent.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.bot.model.event.message;
 
+import java.net.URI;
+
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -36,6 +38,6 @@ public class VideoMessageContent implements MessageContent {
     }
 
     String id;
-    String url;
+    URI url;
     ContentProvider contentProvider;
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/manageaudience/AudienceGroup.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/manageaudience/AudienceGroup.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.bot.model.manageaudience;
 
+import java.net.URI;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -74,7 +76,7 @@ public class AudienceGroup {
      * The URL that was specified when the audience was created. This is only included when
      * audienceGroups[].type is CLICK.
      */
-    String clickUrl;
+    URI clickUrl;
 
     /**
      * The value specified when the audience for uploading user IDs was created, determining which type of

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/manageaudience/request/CreateClickBasedAudienceGroupRequest.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/manageaudience/request/CreateClickBasedAudienceGroupRequest.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.bot.model.manageaudience.request;
 
+import java.net.URI;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -48,7 +50,7 @@ public class CreateClickBasedAudienceGroupRequest {
      *
      * <p>Max: 2,000 characters
      */
-    String clickUrl;
+    URI clickUrl;
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class CreateClickAudienceGroupRequestBuilder {

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/manageaudience/response/CreateClickBasedAudienceGroupResponse.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/manageaudience/response/CreateClickBasedAudienceGroupResponse.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.bot.model.manageaudience.response;
 
+import java.net.URI;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -57,7 +59,7 @@ public class CreateClickBasedAudienceGroupResponse {
     /**
      * The URL that was specified when the audience was created.
      */
-    String clickUrl;
+    URI clickUrl;
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class CreateClickBasedAudienceGroupResponseBuilder {

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Icon.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/flex/component/Icon.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.bot.model.message.flex.component;
 
+import java.net.URI;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -45,7 +47,7 @@ public class Icon implements FlexComponent {
         R3TO1,
     }
 
-    String url;
+    URI url;
 
     FlexFontSize size;
 
@@ -65,7 +67,7 @@ public class Icon implements FlexComponent {
 
     @JsonCreator
     public Icon(
-            @JsonProperty("url") String url,
+            @JsonProperty("url") URI url,
             @JsonProperty("size") FlexFontSize size,
             @JsonProperty("aspectRatio") IconAspectRatio aspectRatio,
             @JsonProperty("margin") FlexMarginSize margin,

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/message/ExampleFlexMessageSupplier.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/message/ExampleFlexMessageSupplier.java
@@ -170,9 +170,9 @@ public class ExampleFlexMessageSupplier implements Supplier<FlexMessage> {
 
     private Box createReviewBox() {
         final Icon goldStar =
-                Icon.builder().size(FlexFontSize.SM).url("https://example.com/gold_star.png").build();
+                Icon.builder().size(FlexFontSize.SM).url(URI.create("https://example.com/gold_star.png")).build();
         final Icon grayStar =
-                Icon.builder().size(FlexFontSize.SM).url("https://example.com/gray_star.png").build();
+                Icon.builder().size(FlexFontSize.SM).url(URI.create("https://example.com/gray_star.png")).build();
         final Text point =
                 Text.builder()
                     .text("4.0")

--- a/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/ExampleFlexMessageSupplier.java
+++ b/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/ExampleFlexMessageSupplier.java
@@ -158,9 +158,9 @@ public class ExampleFlexMessageSupplier implements Supplier<FlexMessage> {
 
     private Box createReviewBox() {
         final Icon goldStar =
-                Icon.builder().size(FlexFontSize.SM).url("https://example.com/gold_star.png").build();
+                Icon.builder().size(FlexFontSize.SM).url(URI.create("https://example.com/gold_star.png")).build();
         final Icon grayStar =
-                Icon.builder().size(FlexFontSize.SM).url("https://example.com/gray_star.png").build();
+                Icon.builder().size(FlexFontSize.SM).url(URI.create("https://example.com/gray_star.png")).build();
         final Text point =
                 Text.builder()
                     .text("4.0")


### PR DESCRIPTION
Resolves #306 
Related PR #360 

Some fields to represent URL remains in using `String` type. 
Replaces `String` with `URI`.
