### PR TITLE
NON-ISSUE Update javadoc for bulk user target limit. (150 -> 500).

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/Multicast.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/Multicast.java
@@ -35,7 +35,7 @@ public class Multicast {
     /**
      * IDs of the receivers.
      *
-     * <p>Max: 150
+     * <p>Max: 500
      *
      * <p>INFO: Use IDs returned via the webhook event of source users. IDs of groups or rooms cannot be used.
      */


### PR DESCRIPTION
https://developers.line.biz/ja/news/2020/04/14/messaging-api-update-april-2020/

![image](https://user-images.githubusercontent.com/1370068/79289929-afd8b380-7f05-11ea-9fd2-99e58da130cd.png)
