### PR TITLE
Rich menu image size limit have been changed

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/richmenu/RichMenuSize.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/richmenu/RichMenuSize.java
@@ -26,11 +26,11 @@ public class RichMenuSize {
     public static final RichMenuSize FULL = new RichMenuSize(2500, 1686);
     public static final RichMenuSize HALF = new RichMenuSize(2500, 843);
 
-    /** Width of the rich menu. Possible values: 2500, 1200, or 800. */
+    /** Width of the rich menu. Possible values: 800px or more. */
     int width;
     /**
      * Height of the rich menu.
-     * Possible values: 1686 or 843 for width = 2500, 810 or 405 for 1200, 540 or 270 for 800.
+     * Possible values: 2500px or less.
      */
     int height;
 


### PR DESCRIPTION
Previous:

    2500px × 1686px
    2500px × 843px
    1200px × 810px
    1200px × 405px
    800px × 540px
    800px × 270p

Current:

    800px or more x 2500px or less

https://developers.line.biz/en/news/2020/05/12/messaging-api-update-may-2020/