### PR TITLE
use assertThatThrownBy instead of ExpectedException.

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -87,6 +87,12 @@
       <message key="import.illegal"
                value="Use AssertJ (org.assertj.core.api.Assumptions.assumeThat) instead." />
     </module>
+    <module name="IllegalImport">
+      <property name="id" value="junitExpectedException" />
+      <property name="illegalClasses" value="org.junit.rules.ExpectedException" />
+      <message key="import.illegal"
+               value="Use AssertJ (org.assertj.core.api.Assertions.assertThatThrownBy) instead." />
+    </module>
 
     <module name="AvoidNestedBlocks">
       <property name="allowInSwitchCase" value="true" />

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/support/ReplyByReturnValueConsumerTest.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/support/ReplyByReturnValueConsumerTest.java
@@ -19,6 +19,7 @@ package com.linecorp.bot.spring.boot.support;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.reset;
@@ -32,7 +33,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.SystemOutRule;
-import org.junit.rules.ExpectedException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
@@ -51,9 +51,6 @@ public class ReplyByReturnValueConsumerTest {
 
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
-
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
 
     @Rule
     public final SystemOutRule systemOut = new SystemOutRule().enableLog();
@@ -157,17 +154,15 @@ public class ReplyByReturnValueConsumerTest {
     // Internal method test.
     @Test
     public void checkListContentsNullTest() throws Exception {
-        expectedException.expect(NullPointerException.class);
-
         // Do
-        ReplyByReturnValueConsumer.checkListContents(singletonList(null));
+        assertThatThrownBy(() -> ReplyByReturnValueConsumer.checkListContents(singletonList(null)))
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     public void checkListContentsIllegalTypeTest() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-
         // Do
-        ReplyByReturnValueConsumer.checkListContents(singletonList(new Object()));
+        assertThatThrownBy(() -> ReplyByReturnValueConsumer.checkListContents(singletonList(new Object())))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
This change makes easier migrating to Junit5.