### PR TITLE
Add keywords to Sticker event

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/StickerMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/StickerMessageContent.java
@@ -16,10 +16,14 @@
 
 package com.linecorp.bot.model.event.message;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import com.linecorp.bot.model.objectmapper.StringArrayOrNullDeserializer;
 
 import lombok.Builder;
 import lombok.Value;
@@ -33,8 +37,15 @@ import lombok.Value;
 @JsonDeserialize(builder = StickerMessageContent.StickerMessageContentBuilder.class)
 public class StickerMessageContent implements MessageContent {
     @JsonPOJOBuilder(withPrefix = "")
-    public static class StickerMessageContentBuilder {
+    public static class StickerMessageContentBuilder implements StickerMessageContentBuilderMeta {
         // Providing builder instead of public constructor. Class body is filled by lombok.
+    }
+
+    @SuppressWarnings("InterfaceMayBeAnnotatedFunctional")
+    private interface StickerMessageContentBuilderMeta {
+        @SuppressWarnings("unused")
+        @JsonDeserialize(using = StringArrayOrNullDeserializer.class)
+        StickerMessageContentBuilder keywords(List<String> keywords);
     }
 
     /**
@@ -83,4 +94,11 @@ public class StickerMessageContent implements MessageContent {
     String packageId;
     String stickerId;
     StickerResourceType stickerResourceType;
+
+    /**
+     * Experimental feature.
+     * List of keywords describing the sticker.
+     * If the type change in the future, this field will become null.
+     */
+    List<String> keywords;
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/objectmapper/StringArrayOrNullDeserializer.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/objectmapper/StringArrayOrNullDeserializer.java
@@ -1,0 +1,38 @@
+package com.linecorp.bot.model.objectmapper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+/**
+ * Fallback to null if the json field is not string of array.
+ */
+public class StringArrayOrNullDeserializer extends StdDeserializer<List<String>> {
+
+    private static final long serialVersionUID = 1L;
+
+    public StringArrayOrNullDeserializer() {
+        super((Class<?>) null);
+    }
+
+    @Override
+    public List<String> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonNode rootNode = p.getCodec().readTree(p);
+        if (!rootNode.isArray()) {
+            return null;
+        }
+        List<String> result = new ArrayList<>();
+        for (JsonNode element : rootNode) {
+            if (!element.isTextual()) {
+                return null;
+            }
+            result.add(element.textValue());
+        }
+        return result;
+    }
+}

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/objectmapper/StringArrayOrNullDeserializer.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/objectmapper/StringArrayOrNullDeserializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.bot.model.objectmapper;
 
 import java.io.IOException;

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/event/CallbackRequestTest.java
@@ -263,6 +263,41 @@ public class CallbackRequestTest {
                         .isEqualTo("1");
                 assertThat(((StickerMessageContent) message).getStickerResourceType())
                         .isEqualTo(StickerResourceType.STATIC);
+                assertThat(((StickerMessageContent) message).getKeywords())
+                        .containsExactly("bed", "sleep", "bedtime");
+            }
+        });
+    }
+
+    @Test
+    public void testStickerKeywordsBecomeString() throws IOException {
+        parse("callback/sticker-keywords-string.json", callbackRequest -> {
+            MessageEvent messageEvent = (MessageEvent) callbackRequest.getEvents().get(0);
+            MessageContent message = messageEvent.getMessage();
+            if (message instanceof StickerMessageContent) {
+                assertThat(((StickerMessageContent) message).getKeywords()).isNull();
+            }
+        });
+    }
+
+    @Test
+    public void testStickerKeywordsBecomeMap() throws IOException {
+        parse("callback/sticker-keywords-map.json", callbackRequest -> {
+            MessageEvent messageEvent = (MessageEvent) callbackRequest.getEvents().get(0);
+            MessageContent message = messageEvent.getMessage();
+            if (message instanceof StickerMessageContent) {
+                assertThat(((StickerMessageContent) message).getKeywords()).isNull();
+            }
+        });
+    }
+
+    @Test
+    public void testStickerKeywordsRemoved() throws IOException {
+        parse("callback/sticker-keywords-remove.json", callbackRequest -> {
+            MessageEvent messageEvent = (MessageEvent) callbackRequest.getEvents().get(0);
+            MessageContent message = messageEvent.getMessage();
+            if (message instanceof StickerMessageContent) {
+                assertThat(((StickerMessageContent) message).getKeywords()).isNull();
             }
         });
     }
@@ -591,7 +626,7 @@ public class CallbackRequestTest {
                     .isEqualTo(EventMode.ACTIVE);
 
             MessageEvent messageEvent = (MessageEvent) event;
-            VideoMessageContent videoMessageContent = (VideoMessageContent)messageEvent.getMessage();
+            VideoMessageContent videoMessageContent = (VideoMessageContent) messageEvent.getMessage();
             assertThat(videoMessageContent.getDuration()).isEqualTo(60000L);
         });
     }

--- a/line-bot-model/src/test/resources/callback/sticker-keywords-map.json
+++ b/line-bot-model/src/test/resources/callback/sticker-keywords-map.json
@@ -16,11 +16,9 @@
         "packageId": "1",
         "stickerId": "1",
         "stickerResourceType": "STATIC",
-        "keywords": [
-          "bed",
-          "sleep",
-          "bedtime"
-        ]
+        "keywords": {
+          "key": "value"
+        }
       }
     }
   ]

--- a/line-bot-model/src/test/resources/callback/sticker-keywords-remove.json
+++ b/line-bot-model/src/test/resources/callback/sticker-keywords-remove.json
@@ -15,12 +15,7 @@
         "type": "sticker",
         "packageId": "1",
         "stickerId": "1",
-        "stickerResourceType": "STATIC",
-        "keywords": [
-          "bed",
-          "sleep",
-          "bedtime"
-        ]
+        "stickerResourceType": "STATIC"
       }
     }
   ]

--- a/line-bot-model/src/test/resources/callback/sticker-keywords-string.json
+++ b/line-bot-model/src/test/resources/callback/sticker-keywords-string.json
@@ -16,11 +16,7 @@
         "packageId": "1",
         "stickerId": "1",
         "stickerResourceType": "STATIC",
-        "keywords": [
-          "bed",
-          "sleep",
-          "bedtime"
-        ]
+        "keywords": "hi,hello"
       }
     }
   ]


### PR DESCRIPTION
Support experimental feature. Try to tolerate unexpected type change in the future.

![415842](https://user-images.githubusercontent.com/863983/102074886-c6465e80-3e48-11eb-83cd-3fe60ca844c8.jpg)


Fix: https://github.com/line/line-bot-sdk-java/issues/598

--
Curious if there is a more nice way to `fallback` type mismatch. 
Also currently if there is no keyword, it also maps to `null`, so it's not easy to know if it's spec changed or no keywords.
