### PR TITLE
Fix Javadoc related to 'addAuthenticationHeader' field

### DIFF
--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineBlobClientBuilder.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineBlobClientBuilder.java
@@ -119,7 +119,7 @@ public class LineBlobClientBuilder {
     /**
      * Add authentication header.
      *
-     * <p>Default = {@value}. If you manage authentication header yourself, set to {@code false}.
+     * <p>Default = {@code true}. If you manage authentication header yourself, set to {@code false}.
      */
     @Setter
     private boolean addAuthenticationHeader = true;
@@ -156,8 +156,9 @@ public class LineBlobClientBuilder {
      *
      * <p>To use this method, please add dependency to 'com.squareup.retrofit2:retrofit'.
      *
-     * @param addAuthenticationHeader If true, all default okhttp interceptors ignored.
-     *         You should insert authentication headers yourself.
+     * @param addAuthenticationHeader If it's true, the default authentication headers will be attached
+     *     to all requests.
+     *     Otherwise if it's false, you should insert your own authentication headers by yourself.
      */
     public LineBlobClientBuilder okHttpClientBuilder(
             final @NonNull OkHttpClient.Builder okHttpClientBuilder,

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClientBuilder.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineMessagingClientBuilder.java
@@ -130,7 +130,7 @@ public class LineMessagingClientBuilder {
     /**
      * Add authentication header.
      *
-     * <p>Default = {@value}. If you manage authentication header yourself, set to {@doe false}.
+     * <p>Default = {@code true}. If you manage authentication header yourself, set to {@code false}.
      */
     @Setter
     private boolean addAuthenticationHeader = true;
@@ -167,8 +167,9 @@ public class LineMessagingClientBuilder {
      *
      * <p>To use this method, please add dependency to 'com.squareup.retrofit2:retrofit'.
      *
-     * @param addAuthenticationHeader If true, all default okhttp interceptors ignored.
-     *         You should insert authentication headers yourself.
+     * @param addAuthenticationHeader If it's true, the default authentication headers will be attached
+     *     to all requests.
+     *     Otherwise if it's false, you should insert your own authentication headers by yourself.
      */
     public LineMessagingClientBuilder okHttpClientBuilder(
             final @NonNull OkHttpClient.Builder okHttpClientBuilder,

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/ManageAudienceBlobClientBuilder.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/ManageAudienceBlobClientBuilder.java
@@ -119,7 +119,7 @@ public class ManageAudienceBlobClientBuilder {
     /**
      * Add authentication header.
      *
-     * <p>Default = {@value}. If you manage authentication header yourself, set to {@code false}.
+     * <p>Default = {@code true}. If you manage authentication header yourself, set to {@code false}.
      */
     @Setter
     private boolean addAuthenticationHeader = true;
@@ -156,8 +156,9 @@ public class ManageAudienceBlobClientBuilder {
      *
      * <p>To use this method, please add dependency to 'com.squareup.retrofit2:retrofit'.
      *
-     * @param addAuthenticationHeader If true, all default okhttp interceptors ignored.
-     *         You should insert authentication headers yourself.
+     * @param addAuthenticationHeader If it's true, the default authentication headers will be attached
+     *     to all requests.
+     *     Otherwise if it's false, you should insert your own authentication headers by yourself.
      */
     public ManageAudienceBlobClientBuilder okHttpClientBuilder(
             final @NonNull OkHttpClient.Builder okHttpClientBuilder,

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/ManageAudienceClientBuilder.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/ManageAudienceClientBuilder.java
@@ -156,8 +156,9 @@ public class ManageAudienceClientBuilder {
      *
      * <p>To use this method, please add dependency to 'com.squareup.retrofit2:retrofit'.
      *
-     * @param addAuthenticationHeader If true, all default okhttp interceptors ignored.
-     *         You should insert authentication headers yourself.
+     * @param addAuthenticationHeader If it's true, the default authentication headers will be attached
+     *     to all requests.
+     *     Otherwise if it's false, you should insert your own authentication headers by yourself.
      */
     public ManageAudienceClientBuilder okHttpClientBuilder(
             final @NonNull OkHttpClient.Builder okHttpClientBuilder,

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/RetryableLineMessagingClientBuilder.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/RetryableLineMessagingClientBuilder.java
@@ -130,7 +130,7 @@ public class RetryableLineMessagingClientBuilder {
     /**
      * Add authentication header.
      *
-     * <p>Default = {@value}. If you manage authentication header yourself, set to {@doe false}.
+     * <p>Default = {@code true}. If you manage authentication header yourself, set to {@code false}.
      */
     @Setter
     private boolean addAuthenticationHeader = true;
@@ -167,8 +167,9 @@ public class RetryableLineMessagingClientBuilder {
      *
      * <p>To use this method, please add dependency to 'com.squareup.retrofit2:retrofit'.
      *
-     * @param addAuthenticationHeader If true, all default okhttp interceptors ignored.
-     *         You should insert authentication headers yourself.
+     * @param addAuthenticationHeader If it's true, the default authentication headers will be attached
+     *     to all requests.
+     *     Otherwise if it's false, you should insert your own authentication headers by yourself.
      */
     public RetryableLineMessagingClientBuilder okHttpClientBuilder(
             final @NonNull OkHttpClient.Builder okHttpClientBuilder,


### PR DESCRIPTION
Modified some Javadoc comments that were a bit confusing (or wrong).

- @value tag in Javadoc can be used only for constants
- The description of `addAuthenticationHeader` parameter on the constructor was a little bit confusing.