### PR TITLE
Add classifier to line-bot-cli jar task

### DIFF
--- a/line-bot-cli/build.gradle
+++ b/line-bot-cli/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
 jar {
     enabled = true
+    archiveClassifier.set('')
 }
 
 bootJar {


### PR DESCRIPTION
Due to changes in spring boot v2.5.x, the following will happen if the spring boot gradle plugin is enabled
- jar task will be enabled by default
- The name of the jar generated by the jar task will be suffixed with -plain.

So, the name of the jar will be changed in line-bot-cli.
In this PR, the name of the jar generated by the jar task will not be suffixed with -plain in line-bot-cli. 
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.5-Release-Notes#gradle-default-jar-and-war-tasks