### PR TITLE
Use wiremock instead of okhttp-mockwebserver.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,7 +29,7 @@ jobs:
         mkdir -p ~/.gradle
         echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
     - run: ./gradlew -v
-    - run: ./gradlew check --info -xcheckstyleMain -xcheckstyleTest -xspotbugsMain -xspotbugsTest
+    - run: ./gradlew check -xcheckstyleMain -xcheckstyleTest -xspotbugsMain -xspotbugsTest
     # Runs all check and its dependency exept which runs on splitted jobs.
 
   checkstyle:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,7 +29,7 @@ jobs:
         mkdir -p ~/.gradle
         echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
     - run: ./gradlew -v
-    - run: ./gradlew check -xcheckstyleMain -xcheckstyleTest -xspotbugsMain -xspotbugsTest
+    - run: ./gradlew check --info -xcheckstyleMain -xcheckstyleTest -xspotbugsMain -xspotbugsTest
     # Runs all check and its dependency exept which runs on splitted jobs.
 
   checkstyle:

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@
  * under the License.
  */
 
-
 import com.github.spotbugs.snom.SpotBugsTask
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.springframework.boot.gradle.plugin.SpringBootPlugin

--- a/build.gradle
+++ b/build.gradle
@@ -225,6 +225,9 @@ subprojects {
         testLogging {
             // Make sure output from standard out or error is shown in Gradle output.
             showStandardStreams = true
+            showExceptions true
+            showCauses true
+            showStackTraces true
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -222,6 +222,10 @@ subprojects {
 
     test {
         useJUnitPlatform()
+        testLogging {
+            // Make sure output from standard out or error is shown in Gradle output.
+            showStandardStreams = true
+        }
     }
 
     project.plugins.withType(SpringBootPlugin) {

--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ subprojects {
         dependencies {
             dependency 'com.google.guava:guava:' + ext['guava.version']
             dependency 'com.github.stefanbirkner:system-lambda:1.2.0'
+            dependency "com.github.tomakehurst:wiremock-jre8:2.30.1"
             dependencySet(group: 'com.squareup.retrofit2', version: ext['retrofit.version']) {
                 entry 'converter-jackson'
                 entry 'retrofit'
@@ -111,7 +112,7 @@ subprojects {
 
         testImplementation 'com.google.guava:guava'
         testImplementation 'com.github.stefanbirkner:system-lambda'
-        testImplementation 'com.squareup.okhttp3:mockwebserver'
+        testImplementation 'com.github.tomakehurst:wiremock-jre8'
         testImplementation 'org.hibernate.validator:hibernate-validator'
         testImplementation 'org.springframework.boot:spring-boot-starter-test' // MockHttpServletRequest
         testImplementation 'org.springframework.boot:spring-boot-starter-logging'

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,9 @@
  * under the License.
  */
 
+
 import com.github.spotbugs.snom.SpotBugsTask
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 // ./gradlew clean && ./gradlew uploadArchives -Prelease
@@ -224,10 +226,11 @@ subprojects {
         useJUnitPlatform()
         testLogging {
             // Make sure output from standard out or error is shown in Gradle output.
-            showStandardStreams = true
+            showStandardStreams true
             showExceptions true
             showCauses true
             showStackTraces true
+            exceptionFormat TestExceptionFormat.FULL
         }
     }
 

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/AbstractWiremockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/AbstractWiremockTest.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.bot.client;
 
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
 import java.net.URI;
 
 import org.junit.After;
@@ -23,6 +25,7 @@ import org.junit.Before;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 
 public abstract class AbstractWiremockTest {
     public static final int ASYNC_TEST_TIMEOUT = 1_000;
@@ -39,8 +42,9 @@ public abstract class AbstractWiremockTest {
 
     @Before
     public void setUpWireMock() {
-        wireMockServer = new WireMockServer();
+        wireMockServer = new WireMockServer(wireMockConfig().dynamicPort());
         wireMockServer.start();
+        WireMock.configureFor("localhost", wireMockServer.port());
 
         lineMessagingClient = createLineMessagingClient(wireMockServer);
         lineBlobClient = createLineBlobClient(wireMockServer);

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/ChannelManagementSyncClientIntegrationWiremockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/ChannelManagementSyncClientIntegrationWiremockTest.java
@@ -41,7 +41,7 @@ public class ChannelManagementSyncClientIntegrationWiremockTest
         extends AbstractWiremockTest {
     private static final ObjectMapper OBJECT_MAPPER = ModelObjectMapper.createNewObjectMapper();
 
-    @Test(timeout = ASYNC_TEST_TIMEOUT)
+    @Test(timeout = 10_000)
     public void testAddLiffMenu() throws Exception {
         // Mocking
         LiffAppAddResponse response = new LiffAppAddResponse("NEW_LIFF_ID");

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/ChannelManagementSyncClientIntegrationWiremockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/ChannelManagementSyncClientIntegrationWiremockTest.java
@@ -18,7 +18,6 @@ package com.linecorp.bot.client;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.getAllServeEvents;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -31,7 +30,6 @@ import java.net.URI;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 
 import com.linecorp.bot.liff.LiffView;
 import com.linecorp.bot.liff.LiffView.Type;
@@ -62,7 +60,6 @@ public class ChannelManagementSyncClientIntegrationWiremockTest
         final LiffAppAddResponse liffAppAddResponse = channelManagementSyncClient.addLiffApp(request);
 
         // Verify
-        final ServeEvent recordedRequest = getAllServeEvents().get(0);
         verify(postRequestedFor(urlEqualTo("/liff/v1/apps"))
                        .withRequestBody(equalTo(OBJECT_MAPPER.writeValueAsString(request))));
         assertThat(liffAppAddResponse.getLiffId())

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/ChannelManagementSyncClientIntegrationWiremockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/ChannelManagementSyncClientIntegrationWiremockTest.java
@@ -16,23 +16,28 @@
 
 package com.linecorp.bot.client;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.getAllServeEvents;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 
 import com.linecorp.bot.liff.LiffView;
 import com.linecorp.bot.liff.LiffView.Type;
 import com.linecorp.bot.liff.request.LiffAppAddRequest;
 import com.linecorp.bot.liff.response.LiffAppAddResponse;
 import com.linecorp.bot.model.objectmapper.ModelObjectMapper;
-
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.RecordedRequest;
 
 public class ChannelManagementSyncClientIntegrationWiremockTest
         extends AbstractWiremockTest {
@@ -42,8 +47,14 @@ public class ChannelManagementSyncClientIntegrationWiremockTest
     public void testAddLiffMenu() throws Exception {
         // Mocking
         LiffAppAddResponse response = new LiffAppAddResponse("NEW_LIFF_ID");
-        mockWebServer.enqueue(new MockResponse().setResponseCode(200)
-                                                .setBody(OBJECT_MAPPER.writeValueAsString(response)));
+        stubFor(
+                post("/liff/v1/apps")
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withBody(OBJECT_MAPPER.writeValueAsString(response))
+                        )
+        );
 
         // Do
         LiffView liffView = new LiffView(Type.COMPACT, URI.create("https://example.com"));
@@ -51,14 +62,9 @@ public class ChannelManagementSyncClientIntegrationWiremockTest
         final LiffAppAddResponse liffAppAddResponse = channelManagementSyncClient.addLiffApp(request);
 
         // Verify
-        final RecordedRequest recordedRequest = mockWebServer.takeRequest();
-        final LiffAppAddRequest requestedBody = OBJECT_MAPPER
-                .readValue(recordedRequest.getBody().readString(StandardCharsets.UTF_8),
-                           LiffAppAddRequest.class);
-        assertThat(requestedBody)
-                .isEqualTo(request);
-        assertThat(recordedRequest.getPath())
-                .isEqualTo("/liff/v1/apps");
+        final ServeEvent recordedRequest = getAllServeEvents().get(0);
+        verify(postRequestedFor(urlEqualTo("/liff/v1/apps"))
+                       .withRequestBody(equalTo(OBJECT_MAPPER.writeValueAsString(request))));
         assertThat(liffAppAddResponse.getLiffId())
                 .isEqualTo("NEW_LIFF_ID");
     }

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/HeaderInterceptorWireMockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/HeaderInterceptorWireMockTest.java
@@ -16,8 +16,11 @@
 
 package com.linecorp.bot.client;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.mockito.Mockito.when;
@@ -41,9 +44,13 @@ public class HeaderInterceptorWireMockTest extends AbstractWiremockTest {
 
     @Test(timeout = ASYNC_TEST_TIMEOUT)
     public void forChannelTokenSupplier() throws Exception {
+        stubFor(get(urlEqualTo("/v2/bot/profile/TEST"))
+                        .willReturn(aResponse().withStatus(200)
+                                               .withBody("{}")));
+
         // Do
         when(channelTokenSupplier.get()).thenReturn("1st");
-        lineMessagingClient.getProfile("TEST");
+        lineMessagingClient.getProfile("TEST").get();
 
         // Verify
         verify(getRequestedFor(urlEqualTo("/v2/bot/profile/TEST"))
@@ -51,7 +58,7 @@ public class HeaderInterceptorWireMockTest extends AbstractWiremockTest {
 
         // Do again with another channel token.
         when(channelTokenSupplier.get()).thenReturn("2nd");
-        lineMessagingClient.getProfile("TEST");
+        lineMessagingClient.getProfile("TEST").get();
 
         // Verify
         verify(getRequestedFor(urlEqualTo("/v2/bot/profile/TEST"))

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientBuilderTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientBuilderTest.java
@@ -16,13 +16,17 @@
 
 package com.linecorp.bot.client;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URI;
+import java.util.concurrent.ExecutionException;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,14 +38,17 @@ public class LineMessagingClientBuilderTest extends AbstractWiremockTest {
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Test
-    public void testBuildWithFixedToken() throws InterruptedException {
+    public void testBuildWithFixedToken() throws InterruptedException, ExecutionException {
+        stubFor(get(urlEqualTo("/v2/bot/profile/TEST"))
+                        .willReturn(aResponse().withBody("{}")));
+
         lineMessagingClient = new LineMessagingClientBuilder()
                 .channelToken("MOCKED_TOKEN")
                 .apiEndPoint(URI.create(wireMockServer.baseUrl()))
                 .build();
 
         // Do
-        lineMessagingClient.getProfile("TEST");
+        lineMessagingClient.getProfile("TEST").get();
 
         // Verify
         verify(getRequestedFor(urlEqualTo("/v2/bot/profile/TEST"))
@@ -49,14 +56,17 @@ public class LineMessagingClientBuilderTest extends AbstractWiremockTest {
     }
 
     @Test
-    public void testBuilderWithChannelTokenSupplier() throws InterruptedException {
+    public void testBuilderWithChannelTokenSupplier() throws InterruptedException, ExecutionException {
+        stubFor(get(urlEqualTo("/v2/bot/profile/TEST"))
+                        .willReturn(aResponse().withBody("{}")));
+
         lineMessagingClient =
                 LineMessagingClient.builder(() -> "MOCKED_TOKEN")
                                    .apiEndPoint(URI.create(wireMockServer.baseUrl()))
                                    .build();
 
         // Do
-        lineMessagingClient.getProfile("TEST");
+        lineMessagingClient.getProfile("TEST").get();
 
         // Verify
         verify(getRequestedFor(urlEqualTo("/v2/bot/profile/TEST"))

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientBuilderTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientBuilderTest.java
@@ -16,7 +16,10 @@
 
 package com.linecorp.bot.client;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URI;
@@ -26,8 +29,6 @@ import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import okhttp3.mockwebserver.RecordedRequest;
-
 public class LineMessagingClientBuilderTest extends AbstractWiremockTest {
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -36,32 +37,30 @@ public class LineMessagingClientBuilderTest extends AbstractWiremockTest {
     public void testBuildWithFixedToken() throws InterruptedException {
         lineMessagingClient = new LineMessagingClientBuilder()
                 .channelToken("MOCKED_TOKEN")
-                .apiEndPoint(URI.create("http://localhost:" + mockWebServer.getPort()))
+                .apiEndPoint(URI.create(wireMockServer.baseUrl()))
                 .build();
 
         // Do
         lineMessagingClient.getProfile("TEST");
 
         // Verify
-        final RecordedRequest recordedRequest = mockWebServer.takeRequest();
-        assertThat(recordedRequest.getHeader("Authorization"))
-                .isEqualTo("Bearer MOCKED_TOKEN");
+        verify(getRequestedFor(urlEqualTo("/v2/bot/profile/TEST"))
+                       .withHeader("Authorization", equalTo("Bearer MOCKED_TOKEN")));
     }
 
     @Test
     public void testBuilderWithChannelTokenSupplier() throws InterruptedException {
         lineMessagingClient =
                 LineMessagingClient.builder(() -> "MOCKED_TOKEN")
-                                   .apiEndPoint(URI.create("http://localhost:" + mockWebServer.getPort()))
+                                   .apiEndPoint(URI.create(wireMockServer.baseUrl()))
                                    .build();
 
         // Do
         lineMessagingClient.getProfile("TEST");
 
         // Verify
-        final RecordedRequest recordedRequest = mockWebServer.takeRequest();
-        assertThat(recordedRequest.getHeader("Authorization"))
-                .isEqualTo("Bearer MOCKED_TOKEN");
+        verify(getRequestedFor(urlEqualTo("/v2/bot/profile/TEST"))
+                       .withHeader("Authorization", equalTo("Bearer MOCKED_TOKEN")));
     }
 
     @Test

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplRichMenuWiremockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplRichMenuWiremockTest.java
@@ -16,14 +16,16 @@
 
 package com.linecorp.bot.client;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
 import com.linecorp.bot.model.response.BotApiResponse;
-
-import okhttp3.mockwebserver.MockResponse;
 
 public class LineMessagingClientImplRichMenuWiremockTest extends AbstractWiremockTest {
     public static final BotApiResponseBody SUCCESS_BODY = new BotApiResponseBody("", emptyList());
@@ -32,8 +34,11 @@ public class LineMessagingClientImplRichMenuWiremockTest extends AbstractWiremoc
     @Test(timeout = ASYNC_TEST_TIMEOUT)
     public void status200WithoutBodyTest() throws Exception {
         // Mocking
-        mockWebServer.enqueue(new MockResponse().setResponseCode(200)
-                                                .addHeader("x-line-request-id", "REQUEST_ID"));
+        stubFor(delete(urlEqualTo("/v2/bot/richmenu/RICH_MENU_ID")).willReturn(
+                aResponse()
+                        .withStatus(200)
+                        .withHeader("x-line-request-id", "REQUEST_ID")
+        ));
 
         // Do
         final BotApiResponse botApiResponse = lineMessagingClient.deleteRichMenu("RICH_MENU_ID").get();
@@ -43,12 +48,16 @@ public class LineMessagingClientImplRichMenuWiremockTest extends AbstractWiremoc
     @Test(timeout = ASYNC_TEST_TIMEOUT)
     public void status200WithBodyTest() throws Exception {
         // Mocking
-        mockWebServer.enqueue(new MockResponse().setResponseCode(200)
-                                                .addHeader("x-line-request-id", "REQUEST_ID")
-                                                .setBody("{}"));
+        stubFor(delete(urlEqualTo("/v2/bot/richmenu/RICH_MENU_ID")).willReturn(
+                aResponse()
+                        .withStatus(200)
+                        .withHeader("x-line-request-id", "REQUEST_ID")
+                        .withBody("{}")
+        ));
 
         // Do
-        final BotApiResponse botApiResponse = lineMessagingClient.deleteRichMenu("RICH_MENU_ID").get();
+        final BotApiResponse botApiResponse = lineMessagingClient.deleteRichMenu("RICH_MENU_ID")
+                                                                 .get();
         assertThat(botApiResponse).isEqualTo(SUCCESS);
     }
 }

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplWiremockTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientImplWiremockTest.java
@@ -16,6 +16,10 @@
 
 package com.linecorp.bot.client;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
@@ -26,6 +30,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.linecorp.bot.client.exception.BadRequestException;
 import com.linecorp.bot.client.exception.ForbiddenException;
@@ -65,7 +71,11 @@ public class LineMessagingClientImplWiremockTest extends AbstractWiremockTest {
     @Test(timeout = ASYNC_TEST_TIMEOUT)
     public void statusCodeHandlerTest() throws Exception {
         // Mocking
-        mocking(statusCode, ERROR_RESPONSE);
+        stubFor(get(urlEqualTo("/v2/bot/message/TOKEN/content"))
+                        .willReturn(aResponse()
+                                            .withStatus(statusCode)
+                                            .withBody(new ObjectMapper().writeValueAsString(
+                                                    ERROR_RESPONSE))));
 
         // Do
         assertThatThrownBy(() -> lineBlobClient.getMessageContent("TOKEN").get())

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineMessagingClientTest.java
@@ -22,6 +22,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
@@ -33,6 +34,7 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 
 import com.linecorp.bot.model.profile.UserProfileResponse;
 
@@ -47,8 +49,9 @@ public class LineMessagingClientTest {
 
     @Before
     public void setUp() throws Exception {
-        wireMockServer = new WireMockServer();
+        wireMockServer = new WireMockServer(wireMockConfig().dynamicPort());
         wireMockServer.start();
+        WireMock.configureFor("localhost", wireMockServer.port());
 
         final String apiEndPoint = wireMockServer.url("/CanContainsRelative/");
         target = LineMessagingClient

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineOAuthClientTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineOAuthClientTest.java
@@ -23,6 +23,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowableOfType;
 
@@ -63,8 +64,10 @@ public class LineOAuthClientTest {
 
     @Before
     public void setUp() {
-        wireMockServer = new WireMockServer();
+        wireMockServer = new WireMockServer(wireMockConfig().dynamicPort());
         wireMockServer.start();
+        WireMock.configureFor("localhost", wireMockServer.port());
+
         final String apiEndPoint = wireMockServer.baseUrl();
         target = LineOAuthClient.builder()
                                 .apiEndPoint(URI.create(apiEndPoint))

--- a/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineOAuthClientTest.java
+++ b/line-bot-api-client/src/test/java/com/linecorp/bot/client/LineOAuthClientTest.java
@@ -16,6 +16,13 @@
 
 package com.linecorp.bot.client;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowableOfType;
 
@@ -28,15 +35,13 @@ import org.junit.Test;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.bot.model.oauth.ChannelAccessTokenException;
 import com.linecorp.bot.model.oauth.IssueChannelAccessTokenRequest;
 import com.linecorp.bot.model.oauth.IssueChannelAccessTokenResponse;
-
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
 
 public class LineOAuthClientTest {
     static {
@@ -53,13 +58,14 @@ public class LineOAuthClientTest {
                                            .accessToken("accessToken")
                                            .build();
 
-    private MockWebServer mockWebServer;
+    private WireMockServer wireMockServer;
     private LineOAuthClient target;
 
     @Before
     public void setUp() {
-        mockWebServer = new MockWebServer();
-        final String apiEndPoint = mockWebServer.url("/").toString();
+        wireMockServer = new WireMockServer();
+        wireMockServer.start();
+        final String apiEndPoint = wireMockServer.baseUrl();
         target = LineOAuthClient.builder()
                                 .apiEndPoint(URI.create(apiEndPoint))
                                 .build();
@@ -67,15 +73,17 @@ public class LineOAuthClientTest {
 
     @After
     public void tearDown() throws Exception {
-        mockWebServer.shutdown();
+        wireMockServer.stop();
     }
 
     @Test
     public void issueToken() throws Exception {
 
-        mockWebServer.enqueue(new MockResponse()
-                                      .setResponseCode(200)
-                                      .setBody(ISSUE_TOKEN_RESPONSE_JSON));
+        stubFor(post(urlEqualTo("/v2/oauth/accessToken")).willReturn(
+                aResponse()
+                        .withStatus(200)
+                        .withBody(ISSUE_TOKEN_RESPONSE_JSON)
+        ));
 
         // Do
         final IssueChannelAccessTokenResponse actualResponse =
@@ -86,22 +94,24 @@ public class LineOAuthClientTest {
                       .join();
 
         // Verify
-        final RecordedRequest recordedRequest = mockWebServer.takeRequest();
-        assertThat(recordedRequest.getPath())
-                .isEqualTo("/v2/oauth/accessToken");
-        assertThat(recordedRequest.getBody().readUtf8())
-                .isEqualTo("grant_type=client_credentials&client_id=clientId&client_secret=clientSecret");
+        verify(postRequestedFor(
+                urlEqualTo("/v2/oauth/accessToken")
+        ).withRequestBody(
+                WireMock.equalTo(
+                        "grant_type=client_credentials&client_id=clientId&client_secret=clientSecret")));
         assertThat(actualResponse).isEqualTo(ISSUE_TOKEN_RESPONSE);
     }
 
     @Test
     public void issueTokenError() throws Exception {
-        mockWebServer.enqueue(new MockResponse()
-                                      .setResponseCode(400)
-                                      .setBody(OBJECT_MAPPER.writeValueAsString(ImmutableMap.of(
-                                              "error", "error",
-                                              "error_description", "errorDetail"
-                                      ))));
+        stubFor(post(urlEqualTo("/v2/oauth/accessToken")).willReturn(
+                aResponse()
+                        .withStatus(400)
+                        .withBody(OBJECT_MAPPER.writeValueAsString(ImmutableMap.of(
+                                "error", "error",
+                                "error_description", "errorDetail"
+                        )))
+        ));
 
         // Do
         final CompletionException actualException =
@@ -113,11 +123,11 @@ public class LineOAuthClientTest {
                                      CompletionException.class);
 
         // Verify
-        final RecordedRequest recordedRequest = mockWebServer.takeRequest();
-        assertThat(recordedRequest.getPath())
-                .isEqualTo("/v2/oauth/accessToken");
-        assertThat(recordedRequest.getBody().readUtf8())
-                .isEqualTo("grant_type=client_credentials&client_id=clientId&client_secret=clientSecret");
+        verify(
+                postRequestedFor(urlEqualTo("/v2/oauth/accessToken"))
+                        .withRequestBody(equalTo(
+                                "grant_type=client_credentials&client_id=clientId&client_secret=clientSecret"
+                        )));
         assertThat(actualException).hasCauseInstanceOf(ChannelAccessTokenException.class);
         final ChannelAccessTokenException e = (ChannelAccessTokenException) actualException.getCause();
         assertThat(e.getError()).isEqualTo("error");
@@ -126,16 +136,16 @@ public class LineOAuthClientTest {
 
     @Test
     public void revokeToken() throws Exception {
-        mockWebServer.enqueue(new MockResponse().setResponseCode(200));
+        stubFor(post(urlEqualTo("/v2/oauth/revoke")).willReturn(
+                aResponse()
+                        .withStatus(200)
+        ));
 
         // Do
         target.revokeChannelToken("accessToken").join();
 
         // Verify
-        final RecordedRequest recordedRequest = mockWebServer.takeRequest();
-        assertThat(recordedRequest.getPath())
-                .isEqualTo("/v2/oauth/revoke");
-        assertThat(recordedRequest.getBody().readUtf8())
-                .isEqualTo("access_token=accessToken");
+        verify(postRequestedFor(urlEqualTo("/v2/oauth/revoke"))
+                       .withRequestBody(equalTo("access_token=accessToken")));
     }
 }

--- a/line-bot-api-client/src/test/resources/logback-test.xml
+++ b/line-bot-api-client/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/basic/IntegrationTest.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/basic/IntegrationTest.java
@@ -23,6 +23,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -49,6 +50,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.common.io.ByteStreams;
 
 import com.linecorp.bot.client.LineMessagingClient;
@@ -120,8 +122,10 @@ public class IntegrationTest {
 
     @BeforeClass
     public static void beforeClass() {
-        server = new WireMockServer();
+        server = new WireMockServer(wireMockConfig().dynamicPort());
         server.start();
+        WireMock.configureFor("localhost", server.port());
+
         System.setProperty("line.bot.apiEndPoint", server.url("/").toString());
     }
 

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/basic/IntegrationTest.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/basic/IntegrationTest.java
@@ -16,7 +16,12 @@
 
 package com.linecorp.bot.spring.boot.integration.basic;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -24,8 +29,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.io.InputStream;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -42,6 +47,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.WebApplicationContext;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.common.io.ByteStreams;
 
 import com.linecorp.bot.client.LineMessagingClient;
@@ -57,9 +64,6 @@ import com.linecorp.bot.spring.boot.integration.basic.IntegrationTest.MyControll
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
 
 // integration test
 @RunWith(SpringRunner.class)
@@ -78,7 +82,7 @@ public class IntegrationTest {
     private WebApplicationContext wac;
 
     private MockMvc mockMvc;
-    private static MockWebServer server;
+    private static WireMockServer server;
 
     @RestController
     @Slf4j
@@ -101,14 +105,14 @@ public class IntegrationTest {
                 if (content instanceof TextMessageContent) {
                     String text = ((TextMessageContent) content).getText();
                     lineMessagingClient.replyMessage(
-                            new ReplyMessage(((MessageEvent) event).getReplyToken(),
-                                             new TextMessage(text)))
+                                               new ReplyMessage(((MessageEvent) event).getReplyToken(),
+                                                                new TextMessage(text)))
                                        .get();
                 }
             } else if (event instanceof FollowEvent) {
                 lineMessagingClient.replyMessage(
-                        new ReplyMessage(((FollowEvent) event).getReplyToken(),
-                                         new TextMessage("follow")))
+                                           new ReplyMessage(((FollowEvent) event).getReplyToken(),
+                                                            new TextMessage("follow")))
                                    .get();
             }
         }
@@ -116,8 +120,14 @@ public class IntegrationTest {
 
     @BeforeClass
     public static void beforeClass() {
-        server = new MockWebServer();
+        server = new WireMockServer();
+        server.start();
         System.setProperty("line.bot.apiEndPoint", server.url("/").toString());
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        server.stop();
     }
 
     @Before
@@ -137,12 +147,13 @@ public class IntegrationTest {
 
     @Test
     public void validCallbackTest() throws Exception {
-        server.enqueue(new MockResponse().setBody("{}"));
-        server.enqueue(new MockResponse().setBody("{}"));
+        stubFor(WireMock.get(urlEqualTo("/"))
+                        .willReturn(aResponse().withBody("{}")));
 
         String signature = "ECezgIpQNUEp4OSHYd7xGSuFG7e66MLPkCkK1Y28XTU=";
 
         InputStream resource = getClass().getClassLoader().getResourceAsStream("callback-request.json");
+        assert resource != null;
         byte[] json = ByteStreams.toByteArray(resource);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/callback")
@@ -152,21 +163,21 @@ public class IntegrationTest {
                .andExpect(status().isOk());
 
         // Test request 1
-        RecordedRequest request1 = server.takeRequest(3, TimeUnit.SECONDS);
-        assertThat(request1.getPath()).isEqualTo("/v2/bot/message/reply");
-        assertThat(request1.getHeader("Authorization")).isEqualTo("Bearer TOKEN");
-        assertThat(request1.getBody().readUtf8())
-                .isEqualTo("{\"replyToken\":\"nHuyWiB7yP5Zw52FIkcQobQuGDXCTA\","
-                           + "\"messages\":[{\"type\":\"text\",\"text\":\"Hello, world\"}],"
-                           + "\"notificationDisabled\":false}");
+        verify(postRequestedFor(urlEqualTo("/v2/bot/message/reply"))
+                       .withHeader("Authorization", equalTo("Bearer TOKEN"))
+                       .withRequestBody(equalTo(
+                               "{\"replyToken\":\"nHuyWiB7yP5Zw52FIkcQobQuGDXCTA\","
+                               + "\"messages\":[{\"type\":\"text\",\"text\":\"Hello, world\"}],"
+                               + "\"notificationDisabled\":false}"
+                       )));
 
         // Test request 2
-        RecordedRequest request2 = server.takeRequest(3, TimeUnit.SECONDS);
-        assertThat(request2.getPath()).isEqualTo("/v2/bot/message/reply");
-        assertThat(request2.getHeader("Authorization")).isEqualTo("Bearer TOKEN");
-        assertThat(request2.getBody().readUtf8())
-                .isEqualTo("{\"replyToken\":\"nHuyWiB7yP5Zw52FIkcQobQuGDXCTA\","
-                           + "\"messages\":[{\"type\":\"text\",\"text\":\"follow\"}],"
-                           + "\"notificationDisabled\":false}");
+        verify(postRequestedFor(urlEqualTo("/v2/bot/message/reply"))
+                       .withHeader("Authorization", equalTo("Bearer TOKEN"))
+                       .withRequestBody(equalTo(
+                               "{\"replyToken\":\"nHuyWiB7yP5Zw52FIkcQobQuGDXCTA\","
+                               + "\"messages\":[{\"type\":\"text\",\"text\":\"follow\"}],"
+                               + "\"notificationDisabled\":false}"
+                       )));
     }
 }

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/basic/IntegrationTest.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/basic/IntegrationTest.java
@@ -18,6 +18,7 @@ package com.linecorp.bot.spring.boot.integration.basic;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -48,7 +49,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.common.io.ByteStreams;
 
 import com.linecorp.bot.client.LineMessagingClient;
@@ -147,7 +147,7 @@ public class IntegrationTest {
 
     @Test
     public void validCallbackTest() throws Exception {
-        stubFor(WireMock.get(urlEqualTo("/"))
+        stubFor(post(urlEqualTo("/v2/bot/message/reply"))
                         .willReturn(aResponse().withBody("{}")));
 
         String signature = "ECezgIpQNUEp4OSHYd7xGSuFG7e66MLPkCkK1Y28XTU=";

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/destination/IntegrationTestWithDestination.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/destination/IntegrationTestWithDestination.java
@@ -23,6 +23,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -47,6 +48,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.common.io.ByteStreams;
 
 import com.linecorp.bot.client.LineMessagingClient;
@@ -114,8 +116,9 @@ public class IntegrationTestWithDestination {
 
     @BeforeClass
     public static void beforeClass() {
-        server = new WireMockServer();
+        server = new WireMockServer(wireMockConfig().dynamicPort());
         server.start();
+        WireMock.configureFor("localhost", server.port());
 
         System.setProperty("line.bot.apiEndPoint", server.url("/"));
     }

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/destination/IntegrationTestWithDestination.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/destination/IntegrationTestWithDestination.java
@@ -159,7 +159,8 @@ public class IntegrationTestWithDestination {
                                "{\"replyToken\":\"nHuyWiB7yP5Zw52FIkcQobQuGDXCTA\","
                                + "\"messages\":["
                                + "{\"type\":\"text\","
-                               + "\"text\":\"Hello, world! with destination U11111111111111111111111111111111\"}],"
+                               + "\"text\":\"Hello, world! with destination"
+                               + " U11111111111111111111111111111111\"}],"
                                + "\"notificationDisabled\":false}"
                        )));
     }

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/destination/IntegrationTestWithDestination.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/destination/IntegrationTestWithDestination.java
@@ -16,14 +16,20 @@
 
 package com.linecorp.bot.spring.boot.integration.destination;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.InputStream;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -40,6 +46,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.WebApplicationContext;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import com.google.common.io.ByteStreams;
 
 import com.linecorp.bot.client.LineMessagingClient;
@@ -55,9 +62,6 @@ import com.linecorp.bot.spring.boot.integration.destination.IntegrationTestWithD
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
 
 // integration test
 @RunWith(SpringRunner.class)
@@ -76,7 +80,7 @@ public class IntegrationTestWithDestination {
     private WebApplicationContext wac;
 
     private MockMvc mockMvc;
-    private static MockWebServer server;
+    private static WireMockServer server;
 
     @RestController
     @Slf4j
@@ -100,8 +104,8 @@ public class IntegrationTestWithDestination {
                 if (content instanceof TextMessageContent) {
                     String text = ((TextMessageContent) content).getText();
                     lineMessagingClient.replyMessage(
-                            new ReplyMessage(((MessageEvent) event).getReplyToken(),
-                                             new TextMessage(text + " " + destination)))
+                                               new ReplyMessage(((MessageEvent) event).getReplyToken(),
+                                                                new TextMessage(text + " " + destination)))
                                        .get();
                 }
             }
@@ -110,8 +114,15 @@ public class IntegrationTestWithDestination {
 
     @BeforeClass
     public static void beforeClass() {
-        server = new MockWebServer();
-        System.setProperty("line.bot.apiEndPoint", server.url("/").toString());
+        server = new WireMockServer();
+        server.start();
+
+        System.setProperty("line.bot.apiEndPoint", server.url("/"));
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        server.stop();
     }
 
     @Before
@@ -122,12 +133,17 @@ public class IntegrationTestWithDestination {
 
     @Test
     public void validCallbackTest() throws Exception {
-        server.enqueue(new MockResponse().setBody("{}"));
+        stubFor(post(urlEqualTo("/v2/bot/message/reply")).willReturn(
+                aResponse()
+                        .withStatus(200)
+                        .withBody("{}}")
+        ));
 
         String signature = "JrTTkLoW+Qj8pWajBMzZJ70O3katMjJKUlXaMFiIdkI=";
 
         InputStream resource = getClass().getClassLoader()
                                          .getResourceAsStream("callback-request-with-destination.json");
+        assert resource != null;
         byte[] json = ByteStreams.toByteArray(resource);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/callback")
@@ -137,14 +153,14 @@ public class IntegrationTestWithDestination {
                .andExpect(status().isOk());
 
         // Test request 1
-        RecordedRequest request1 = server.takeRequest(3, TimeUnit.SECONDS);
-        assertThat(request1.getPath()).isEqualTo("/v2/bot/message/reply");
-        assertThat(request1.getHeader("Authorization")).isEqualTo("Bearer TOKEN");
-        assertThat(request1.getBody().readUtf8())
-                .isEqualTo("{\"replyToken\":\"nHuyWiB7yP5Zw52FIkcQobQuGDXCTA\","
-                           + "\"messages\":["
-                           + "{\"type\":\"text\","
-                           + "\"text\":\"Hello, world! with destination U11111111111111111111111111111111\"}],"
-                           + "\"notificationDisabled\":false}");
+        verify(postRequestedFor(urlEqualTo("/v2/bot/message/reply"))
+                       .withHeader("Authorization", equalTo("Bearer TOKEN"))
+                       .withRequestBody(equalTo(
+                               "{\"replyToken\":\"nHuyWiB7yP5Zw52FIkcQobQuGDXCTA\","
+                               + "\"messages\":["
+                               + "{\"type\":\"text\","
+                               + "\"text\":\"Hello, world! with destination U11111111111111111111111111111111\"}],"
+                               + "\"notificationDisabled\":false}"
+                       )));
     }
 }

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/destination_handler/IntegrationTestWithDestinationHandler.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/destination_handler/IntegrationTestWithDestinationHandler.java
@@ -23,6 +23,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -44,6 +45,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.common.io.ByteStreams;
 
 import com.linecorp.bot.client.LineMessagingClient;
@@ -93,8 +95,10 @@ public class IntegrationTestWithDestinationHandler {
 
     @BeforeClass
     public static void beforeClass() {
-        server = new WireMockServer();
+        server = new WireMockServer(wireMockConfig().dynamicPort());
         server.start();
+        WireMock.configureFor("localhost", server.port());
+
         System.setProperty("line.bot.apiEndPoint", server.baseUrl());
     }
 

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/destination_handler/IntegrationTestWithDestinationHandler.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/destination_handler/IntegrationTestWithDestinationHandler.java
@@ -17,6 +17,8 @@
 package com.linecorp.bot.spring.boot.integration.destination_handler;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
@@ -132,6 +134,7 @@ public class IntegrationTestWithDestinationHandler {
                .andExpect(status().isOk());
 
         // Test request 1
+        verify(anyRequestedFor(anyUrl()));
         verify(postRequestedFor(urlEqualTo("/v2/bot/message/reply"))
                        .withHeader("Authorization", equalTo("Bearer TOKEN"))
                        .withRequestBody(equalTo(

--- a/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/destination_handler/IntegrationTestWithDestinationHandler.java
+++ b/line-bot-spring-boot/src/test/java/com/linecorp/bot/spring/boot/integration/destination_handler/IntegrationTestWithDestinationHandler.java
@@ -18,6 +18,7 @@ package com.linecorp.bot.spring.boot.integration.destination_handler;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -43,7 +44,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.common.io.ByteStreams;
 
 import com.linecorp.bot.client.LineMessagingClient;
@@ -111,7 +111,7 @@ public class IntegrationTestWithDestinationHandler {
 
     @Test
     public void validCallbackTest() throws Exception {
-        stubFor(WireMock.get(urlEqualTo("/v2/bot/message/reply"))
+        stubFor(post(urlEqualTo("/v2/bot/message/reply"))
                         .willReturn(aResponse().withBody("{}")));
 
         String signature = "JrTTkLoW+Qj8pWajBMzZJ70O3katMjJKUlXaMFiIdkI=";

--- a/line-bot-spring-boot/src/test/resources/logback-test.xml
+++ b/line-bot-spring-boot/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
- okhttp-mockwebserver depends on JUnit4.
- okhttp-mockwebserver alpha version can use with JUnit5. But it's not
  released yet.