### PR TITLE
Procfile: Use the uber jar explicitly.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java $JAVA_OPTS -jar sample-spring-boot-echo/build/libs/sample-spring-boot-echo-*.jar --server.port=$PORT
+web: java $JAVA_OPTS -jar sample-spring-boot-echo/build/libs/sample-spring-boot-echo-*-SNAPSHOT.jar --server.port=$PORT


### PR DESCRIPTION
Latest spring boot generates two jars in the same directory.

e.g.
- sample-spring-boot-echo/build/libs/sample-spring-boot-echo-4.7.0-SNAPSHOT-plain.jar
- sample-spring-boot-echo/build/libs/sample-spring-boot-echo-4.7.0-SNAPSHOT.jar