### PR TITLE
Use `mainClass` instead of deprecated `mainClassName`

### DIFF
--- a/line-bot-cli/build.gradle
+++ b/line-bot-cli/build.gradle
@@ -36,7 +36,7 @@ bootJar {
         script = file('src/main/resources/launch.script')
     }
     archiveClassifier.set('exec')
-    mainClassName = 'com.linecorp.bot.cli.Application'
+    mainClass = 'com.linecorp.bot.cli.Application'
 }
 
 // Reset bootRepackage dependency to remove dependency from bootRepackage to signArchives.


### PR DESCRIPTION
`mainClassName` field was removed since spring boot 2.6.0