### PR TITLE
Update to Boot 2.7.0 from 2.6.7.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 buildscript {
     ext {
         kotlin_version = '1.6.21'
-        spring_boot_version = '2.6.7'
+        spring_boot_version = '2.7.0'
     }
 
     repositories {

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineBlobClientImpl.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/LineBlobClientImpl.java
@@ -44,6 +44,7 @@ class LineBlobClientImpl implements LineBlobClient {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // RequestBody.create
     public CompletableFuture<BotApiResponse> setRichMenuImage(
             final String richMenuId, final String contentType, final byte[] content) {
         final RequestBody requestBody = RequestBody.create(MediaType.parse(contentType), content);

--- a/line-bot-api-client/src/main/java/com/linecorp/bot/client/ManageAudienceBlobClientImpl.java
+++ b/line-bot-api-client/src/main/java/com/linecorp/bot/client/ManageAudienceBlobClientImpl.java
@@ -44,6 +44,7 @@ public class ManageAudienceBlobClientImpl implements ManageAudienceBlobClient {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // RequestBody.create
     public CompletableFuture<CreateAudienceForUploadingResponse> createAudienceForUploadingUserIds(
             String description, boolean isIfaAudience, String uploadDescription, File file) {
         MultipartBody parts = new MultipartBody.Builder()
@@ -58,6 +59,7 @@ public class ManageAudienceBlobClientImpl implements ManageAudienceBlobClient {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // RequestBody.create
     public CompletableFuture<BotApiResponse> addUserIdsToAudience(long audienceGroupId,
                                                                   String uploadDescription,
                                                                   File file) {


### PR DESCRIPTION
- OkHttp's RequestBody.create was deprecated but the suggested new
  method is not available for pure java(it's kotlin's extension method)