### PR TITLE
Make `duration` field as long.

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/AudioMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/AudioMessageContent.java
@@ -38,5 +38,5 @@ public class AudioMessageContent implements MessageContent {
 
     String id;
     ContentProvider contentProvider;
-    Integer duration;
+    Long duration;
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/VideoMessageContent.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/event/message/VideoMessageContent.java
@@ -37,6 +37,6 @@ public class VideoMessageContent implements MessageContent {
     /**
      * Length of video file (milliseconds).
      */
-    Integer duration;
+    Long duration;
     ContentProvider contentProvider;
 }

--- a/line-bot-model/src/main/java/com/linecorp/bot/model/message/AudioMessage.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/message/AudioMessage.java
@@ -51,7 +51,7 @@ public class AudioMessage implements Message {
     /**
      * Length of audio file (milliseconds).
      */
-    Integer duration;
+    Long duration;
 
     QuickReply quickReply;
 
@@ -62,7 +62,7 @@ public class AudioMessage implements Message {
      *
      * <p>If you want use {@link QuickReply}, please use {@link #builder()} instead.
      */
-    public AudioMessage(final URI originalContentUrl, final Integer duration) {
+    public AudioMessage(final URI originalContentUrl, final Long duration) {
         this(originalContentUrl, duration, null, null);
     }
 

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/message/AudioMessageTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/message/AudioMessageTest.java
@@ -29,7 +29,7 @@ public class AudioMessageTest {
 
     @Test
     public void constructor() {
-        AudioMessage message = new AudioMessage(URI.create("https://example.com/"), 3);
+        AudioMessage message = new AudioMessage(URI.create("https://example.com/"), 3L);
         assertThat(message.getOriginalContentUrl()).isEqualTo(URI.create("https://example.com/"));
         assertThat(message.getDuration()).isEqualTo(3);
         assertThat(message.getQuickReply()).isNull();
@@ -41,7 +41,7 @@ public class AudioMessageTest {
         AudioMessage message = AudioMessage
                 .builder()
                 .originalContentUrl(URI.create("https://example.com/"))
-                .duration(3)
+                .duration(3L)
                 .quickReply(null)
                 .sender(Sender.builder()
                               .name("hello")

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/message/MessageJsonReconstructionTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/message/MessageJsonReconstructionTest.java
@@ -124,7 +124,7 @@ public class MessageJsonReconstructionTest {
 
     @Test
     public void audioMessageTest() {
-        test(new AudioMessage(URI.create("http://originalUrl"), 20));
+        test(new AudioMessage(URI.create("http://originalUrl"), 20L));
     }
 
     @Test

--- a/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/KitchenSinkController.java
+++ b/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/KitchenSinkController.java
@@ -174,7 +174,7 @@ public class KitchenSinkController {
                     } else {
                         mp4 = saveContent("mp4", responseBody);
                     }
-                    reply(event.getReplyToken(), new AudioMessage(mp4.getUri(), 100));
+                    reply(event.getReplyToken(), new AudioMessage(mp4.getUri(), 100L));
                 });
     }
 


### PR DESCRIPTION
- AudioMessageContent.duration, VideoMessageContent.duration, AudioMessage.duration

LINE's server sends/receives long value to these fields.

This PR breaks binary compatibility. We'll do the major version up after merging this PR.