### PR TITLE
Use gradle's standard dependency management mechanism.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,6 @@
  * under the License.
  */
 
-import com.github.spotbugs.snom.SpotBugsTask
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
@@ -27,7 +26,6 @@ plugins {
     signing
     id("org.jetbrains.kotlin.jvm") version "1.7.10" apply false
     id("com.github.spotbugs") version "5.0.9" apply false
-    id("io.spring.dependency-management") version "1.0.12.RELEASE" apply false
     id("org.springframework.boot") version "2.7.2" apply false
     id("io.freefair.lombok") version "6.5.0.3"
 }
@@ -55,7 +53,6 @@ subprojects {
         plugin("com.github.spotbugs")
         plugin("java-library")
         plugin("checkstyle")
-        plugin("io.spring.dependency-management")
         plugin("io.freefair.lombok")
     }
 
@@ -67,25 +64,9 @@ subprojects {
     group = rootProject.group
     version = rootProject.version
 
-    configure<io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension> {
-        imports {
-            mavenBom(SpringBootPlugin.BOM_COORDINATES)
-        }
-
-        dependencies {
-            dependency("com.google.guava:guava:31.1-jre")
-            dependency("com.github.stefanbirkner:system-lambda:1.2.1")
-            dependency("com.github.tomakehurst:wiremock-jre8:2.33.2")
-            dependencySet("com.squareup.retrofit2:2.9.0") {
-                entry("converter-jackson")
-                entry("retrofit")
-            }
-            dependencySet("io.jsonwebtoken:0.11.5") {
-                entry("jjwt-api")
-                entry("jjwt-impl")
-                entry("jjwt-jackson")
-            }
-        }
+    dependencies {
+        implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
+        annotationProcessor(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
     }
 
     tasks.named("compileJava") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,18 @@
+[versions]
+jsonwebtoken = "0.11.5"
+retrofit2 = "2.9.0"
+jjwt = "0.11.5"
+
+[libraries]
+retrofit2-retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit2" }
+retrofit2-converter-jackson = { module = "com.squareup.retrofit2:converter-jackson", version.ref = "retrofit2" }
+guava = { group = "com.google.guava", name = "guava", version = "31.1-jre" }
+system-lambda = { group = "com.github.stefanbirkner", name = "system-lambda", version = "1.2.1" }
+wiremock = { group = "com.github.tomakehurst", name = "wiremock-jre8", version = "2.33.2" }
+jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jjwt" }
+jjwt-impl = { module = "io.jsonwebtoken:jjwt-impl", version.ref = "jjwt" }
+jjwt-jackson = { module = "io.jsonwebtoken:jjwt-jackson", version.ref = "jjwt" }
+
+[bundles]
+retrofit2 = ["retrofit2-converter-jackson", "retrofit2-retrofit"]
+

--- a/line-bot-api-client/build.gradle.kts
+++ b/line-bot-api-client/build.gradle.kts
@@ -50,21 +50,20 @@ dependencies {
     api(project(":line-bot-model"))
     implementation("org.slf4j:slf4j-api")
     implementation("com.squareup.okhttp3:logging-interceptor")
-    implementation("com.squareup.retrofit2:converter-jackson")
-    implementation("com.squareup.retrofit2:retrofit")
+    implementation(libs.bundles.retrofit2)
 
     testCompileOnly("org.projectlombok:lombok")
     testAnnotationProcessor("org.projectlombok:lombok")
 
-    testImplementation("com.github.stefanbirkner:system-lambda")
-    testImplementation("com.github.tomakehurst:wiremock-jre8")
+    testImplementation(libs.system.lambda)
+    testImplementation(libs.wiremock)
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 
     integrationTestCompileOnly("org.projectlombok:lombok")
     integrationTestAnnotationProcessor("org.projectlombok:lombok")
-    integrationTestImplementation("com.google.guava:guava")
-    integrationTestImplementation("io.jsonwebtoken:jjwt-api")
-    integrationTestImplementation("io.jsonwebtoken:jjwt-jackson")
+    integrationTestImplementation(libs.guava)
+    integrationTestImplementation(libs.jjwt.api)
+    integrationTestImplementation(libs.jjwt.jackson)
     // https://github.com/jwtk/jjwt/issues/236 jjwt doens't support JWK parsing, yet.
     // Once jjwt support JWK, we can remove this dependency.
     integrationTestImplementation("com.nimbusds:nimbus-jose-jwt:9.23")
@@ -78,5 +77,5 @@ dependencies {
     integrationTestImplementation("org.junit.vintage:junit-vintage-engine") {
         exclude(group = "org.hamcrest", module = "hamcrest-core")
     }
-    integrationTestRuntimeOnly("io.jsonwebtoken:jjwt-impl")
+    integrationTestRuntimeOnly(libs.jjwt.impl)
 }

--- a/line-bot-cli/build.gradle.kts
+++ b/line-bot-cli/build.gradle.kts
@@ -22,10 +22,10 @@ dependencies {
     implementation(project(":line-bot-spring-boot"))
     implementation(project(":line-bot-api-client"))
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("com.google.guava:guava")
+    implementation(libs.guava)
     implementation("org.yaml:snakeyaml")
 
-    testImplementation("com.github.stefanbirkner:system-lambda")
+    testImplementation(libs.system.lambda)
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/line-bot-model/build.gradle.kts
+++ b/line-bot-model/build.gradle.kts
@@ -23,6 +23,6 @@ dependencies {
 
     testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     testImplementation("com.fasterxml.jackson.module:jackson-module-parameter-names")
-    testImplementation("com.google.guava:guava")
+    testImplementation(libs.guava)
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/line-bot-parser/build.gradle.kts
+++ b/line-bot-parser/build.gradle.kts
@@ -19,6 +19,6 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("org.slf4j:slf4j-api")
 
-    testImplementation("com.google.guava:guava")
+    testImplementation(libs.guava)
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/line-bot-servlet/build.gradle.kts
+++ b/line-bot-servlet/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     api(project(":line-bot-model"))
     implementation(project(":line-bot-parser"))
     implementation("com.fasterxml.jackson.core:jackson-databind")
-    implementation("com.google.guava:guava")
+    implementation(libs.guava)
 
     compileOnly("javax.servlet:javax.servlet-api")
     compileOnly("org.slf4j:slf4j-api")

--- a/line-bot-spring-boot/build.gradle.kts
+++ b/line-bot-spring-boot/build.gradle.kts
@@ -20,12 +20,12 @@ dependencies {
     implementation(project(":line-bot-parser"))
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("com.google.guava:guava")
+    implementation(libs.guava)
 
     compileOnly("javax.validation:validation-api")
 
-    testImplementation("com.github.stefanbirkner:system-lambda")
-    testImplementation("com.github.tomakehurst:wiremock-jre8")
+    testImplementation(libs.system.lambda)
+    testImplementation(libs.wiremock)
     testImplementation("org.hibernate.validator:hibernate-validator")
     testImplementation("org.springframework.boot:spring-boot-starter-test") // MockHttpServletRequest
     testImplementation("org.springframework.boot:spring-boot-starter-logging")

--- a/sample-spring-boot-kitchensink/build.gradle.kts
+++ b/sample-spring-boot-kitchensink/build.gradle.kts
@@ -19,5 +19,5 @@ apply(plugin = "org.springframework.boot")
 dependencies {
     implementation(project(":line-bot-spring-boot"))
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("com.google.guava:guava")
+    implementation(libs.guava)
 }


### PR DESCRIPTION
Intead of io.spring.dependency-management

This patch will change the behavior of the pom generation.

```
--- ~/.m2/repository/com/linecorp/bot/line-bot-api-client/5.0.1-SNAPSHOT/line-bot-api-client-5.0.1-SNAPSHOT.pom.orig	2022-08-10 20:57:55.000000000 +0900
+++ ~/.m2/repository/com/linecorp/bot/line-bot-api-client/5.0.1-SNAPSHOT/line-bot-api-client-5.0.1-SNAPSHOT.pom	2022-08-10 20:58:17.000000000 +0900
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <!-- This module was also published with a richer model, Gradle metadata,  -->
   <!-- which should be used instead. Do not delete the following line which  -->
   <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
@@ -35,6 +36,17 @@
     <developerConnection>scm:git@github.com:line/line-bot-sdk-java.git</developerConnection>
     <url>scm:git@github.com:line/line-bot-sdk-java.git</url>
   </scm>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>2.7.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>com.linecorp.bot</groupId>
@@ -55,63 +67,14 @@
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>converter-jackson</artifactId>
+      <version>2.9.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>retrofit</artifactId>
+      <version>2.9.0</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.7.2</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>io.jsonwebtoken</groupId>
-        <artifactId>jjwt-jackson</artifactId>
-        <version>0.11.5</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jsonwebtoken</groupId>
-        <artifactId>jjwt-api</artifactId>
-        <version>0.11.5</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>31.1-jre</version>
-      </dependency>
-      <dependency>
-        <groupId>com.squareup.retrofit2</groupId>
-        <artifactId>retrofit</artifactId>
-        <version>2.9.0</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jsonwebtoken</groupId>
-        <artifactId>jjwt-impl</artifactId>
-        <version>0.11.5</version>
-      </dependency>
-      <dependency>
-        <groupId>com.github.stefanbirkner</groupId>
-        <artifactId>system-lambda</artifactId>
-        <version>1.2.1</version>
-      </dependency>
-      <dependency>
-        <groupId>com.squareup.retrofit2</groupId>
-        <artifactId>converter-jackson</artifactId>
-        <version>2.9.0</version>
-      </dependency>
-      <dependency>
-        <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock-jre8</artifactId>
-        <version>2.33.2</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 </project>
```
