### PR TITLE
Use As.EXISTING_PROPERTY not to generate JSON with duplicate keys

### DIFF
--- a/line-bot-model/src/main/java/com/linecorp/bot/model/narrowcast/recipient/Recipient.java
+++ b/line-bot-model/src/main/java/com/linecorp/bot/model/narrowcast/recipient/Recipient.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
-@JsonTypeInfo(use = Id.NAME, property = "type")
+@JsonTypeInfo(use = Id.NAME, property = "type", include = JsonTypeInfo.As.EXISTING_PROPERTY)
 @JsonSubTypes({
         @JsonSubTypes.Type(AudienceRecipient.class),
         @JsonSubTypes.Type(LogicalOperatorRecipient.class),

--- a/line-bot-model/src/test/java/com/linecorp/bot/model/NarrowcastTest.java
+++ b/line-bot-model/src/test/java/com/linecorp/bot/model/NarrowcastTest.java
@@ -79,6 +79,18 @@ public class NarrowcastTest {
     }
 
     @Test
+    public void testRecipientSerializeAudience() throws JsonProcessingException {
+            ObjectMapper objectMapper = ModelObjectMapper.createNewObjectMapper();
+            String content = "{\"audienceGroupId\":59693,\"type\":\"audience\"}";
+            Recipient recipient = objectMapper.readValue(
+                            content,
+                            Recipient.class);
+            assertThat(recipient).isInstanceOf(AudienceRecipient.class);
+            String json = objectMapper.writeValueAsString(recipient);
+            assertThat(json).isEqualTo(content);
+    }
+
+    @Test
     public void testRecipientDeserializeOperator() throws JsonProcessingException {
         ObjectMapper objectMapper = ModelObjectMapper.createNewObjectMapper();
         Recipient recipient = objectMapper.readValue(


### PR DESCRIPTION
Hi,

We found `com.linecorp.bot.model.narrowcast.recipient` generated JSON with duplicate keys.
For example, audience class is serialized like below.
```json
{
    "type":"audience",
    "audienceGroupId": 123,
    "type":"audience"
}
```

https://github.com/FasterXML/jackson-databind/issues/528 reported this. The audience class has type filed and generates duplicate `"type": "audience"` if this class doesn't have `@JsonTypeInfo(include = JsonTypeInfo.As.EXISTING_PROPERTY)`. 
Other models don't have type filed, so it's enough to add this config to only this class.

About JSON format, https://www.rfc-editor.org/rfc/rfc7159#section-4 says
> ... The names within an object SHOULD be unique. ...

So this change follows JSON format the RFC defines.

Thanks!