### PR TITLE
Add line-openapi-update label if github action is run by workflow_dispatch

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -14,6 +14,8 @@ changelog:
       labels:
         - bug-fix
     - title: Dependency updates
+      labels:
+        - dependency upgrade
       exclude:
         labels:
           - line-openapi-update

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,7 +5,6 @@ changelog:
       labels:
         - breaking-change
     - title: line-openapi updates
-      authors: renovate
       labels:
         - line-openapi-update
     - title: New Features
@@ -15,7 +14,6 @@ changelog:
       labels:
         - bug-fix
     - title: Dependency updates
-      authors: renovate
       exclude:
         labels:
           - line-openapi-update

--- a/.github/workflows/update-git-submodule.yml
+++ b/.github/workflows/update-git-submodule.yml
@@ -30,6 +30,6 @@ jobs:
           git add .
           git commit -m "Update line-openapi"
           git push origin update-diff-$CURRENT_DATETIME
-          gh pr create -B ${{ github.ref_name }} --title "Update line-openapi" --body ""
+          gh pr create -B ${{ github.ref_name }} --title "Update line-openapi" --body "" --label "line-openapi-update"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`.github/release.yml` is very helpful to release change.
When we run `.github/workflows/update-git-submodule.yml` manually (by `workflow_dispatch`), different label is attached. This pull request fixes it.