### PR TITLE
Add Quote message feature

### DIFF
--- a/buildSrc/src/main/resources/body/model/StickerMessage.java
+++ b/buildSrc/src/main/resources/body/model/StickerMessage.java
@@ -1,3 +1,3 @@
 public StickerMessage(String packageId, String stickerId) {
-    this(null, null, packageId, stickerId);
+    this(null, null, packageId, stickerId, null);
 }

--- a/buildSrc/src/main/resources/body/model/TextMessage.java
+++ b/buildSrc/src/main/resources/body/model/TextMessage.java
@@ -1,3 +1,3 @@
 public TextMessage(String text) {
-    this(null, null, text, null);
+    this(null, null, text, null, null);
 }

--- a/line-bot-integration-test/src/integrationTest/java/com/linecorp/bot/client/InsightIntegrationTest.java
+++ b/line-bot-integration-test/src/integrationTest/java/com/linecorp/bot/client/InsightIntegrationTest.java
@@ -58,7 +58,7 @@ public class InsightIntegrationTest {
         checkNumberOfFollowersForNarrowcast();
 
         // Send narrowcast message.
-        Result<Void> result = messagingApiClient.narrowcast(
+        Result<Object> result = messagingApiClient.narrowcast(
                 null, new NarrowcastRequest(
                         List.of(new TextMessage("Narrowcast test(gender=male)")),
                         null,

--- a/line-bot-integration-test/src/integrationTest/java/com/linecorp/bot/client/NarrowcastIntegrationTest.java
+++ b/line-bot-integration-test/src/integrationTest/java/com/linecorp/bot/client/NarrowcastIntegrationTest.java
@@ -90,7 +90,7 @@ public class NarrowcastIntegrationTest {
     }
 
     private void testNarrowcast(NarrowcastRequest narrowcast) throws Exception {
-        Result<Void> response = target.narrowcast(null, narrowcast).get();
+        Result<Object> response = target.narrowcast(null, narrowcast).get();
         log.info("Narrowcast response={}", response);
         for (int i = 0; i < 10; i++) {
             NarrowcastProgressResponse progressResponse = target.getNarrowcastProgress(

--- a/samples/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/KitchenSinkController.java
+++ b/samples/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/KitchenSinkController.java
@@ -64,6 +64,7 @@ import com.linecorp.bot.messaging.model.MessageAction;
 import com.linecorp.bot.messaging.model.MessageImagemapAction;
 import com.linecorp.bot.messaging.model.PostbackAction;
 import com.linecorp.bot.messaging.model.ReplyMessageRequest;
+import com.linecorp.bot.messaging.model.ReplyMessageResponse;
 import com.linecorp.bot.messaging.model.RoomMemberCountResponse;
 import com.linecorp.bot.messaging.model.Sender;
 import com.linecorp.bot.messaging.model.StickerMessage;
@@ -316,7 +317,7 @@ public class KitchenSinkController {
         try {
             Objects.requireNonNull(replyToken, "replyToken");
             Objects.requireNonNull(messages, "messages");
-            Result<Void> apiResponse = messagingApiClient
+            Result<ReplyMessageResponse> apiResponse = messagingApiClient
                     .replyMessage(new ReplyMessageRequest(replyToken, messages, notificationDisabled))
                     .get();
             log.info("Sent messages: {}", apiResponse);
@@ -634,6 +635,7 @@ public class KitchenSinkController {
                             null,
                             new Sender("Cat", createUri("/static/icon/cat.png")),
                             "Hello, I'm cat! Meow~",
+                            null,
                             null));
             default -> {
                 log.info("Returns echo message {}: {}", replyToken, text);

--- a/samples/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/MessageWithQuickReplySupplier.java
+++ b/samples/sample-spring-boot-kitchensink/src/main/java/com/example/bot/spring/MessageWithQuickReplySupplier.java
@@ -49,6 +49,6 @@ public class MessageWithQuickReplySupplier implements Supplier<Message> {
 
         final QuickReply quickReply = new QuickReply(items);
 
-        return new TextMessage(quickReply, null, "Message with QuickReply", null);
+        return new TextMessage(quickReply, null, "Message with QuickReply", null, null);
     }
 }

--- a/spring-boot/line-bot-spring-boot-handler/src/main/java/com/linecorp/bot/spring/boot/handler/support/ReplyByReturnValueConsumer.java
+++ b/spring-boot/line-bot-spring-boot-handler/src/main/java/com/linecorp/bot/spring/boot/handler/support/ReplyByReturnValueConsumer.java
@@ -31,6 +31,7 @@ import com.linecorp.bot.client.base.Result;
 import com.linecorp.bot.messaging.client.MessagingApiClient;
 import com.linecorp.bot.messaging.model.Message;
 import com.linecorp.bot.messaging.model.ReplyMessageRequest;
+import com.linecorp.bot.messaging.model.ReplyMessageResponse;
 import com.linecorp.bot.webhook.model.Event;
 import com.linecorp.bot.webhook.model.ReplyEvent;
 
@@ -103,7 +104,7 @@ class ReplyByReturnValueConsumer implements Consumer<Object> {
         // DO NOT BLOCK HERE, otherwise, next message processing will be BLOCKED.
     }
 
-    private void logging(final Result<Void> unused, final Throwable throwable) {
+    private void logging(final Result<ReplyMessageResponse> unused, final Throwable throwable) {
         if (throwable == null) {
             log.debug("Reply message success");
         } else {

--- a/spring-boot/line-bot-spring-boot-handler/src/test/java/com/linecorp/bot/spring/boot/handler/argument/MessageContentArgumentResolverTest.java
+++ b/spring-boot/line-bot-spring-boot-handler/src/test/java/com/linecorp/bot/spring/boot/handler/argument/MessageContentArgumentResolverTest.java
@@ -32,10 +32,10 @@ class MessageContentArgumentResolverTest {
         var resolver = new MessageContentArgumentResolver(TextMessageContent.class);
         assertThat(resolver.isSupported(
                 new MessageEvent(null, null, null, null, null, null,
-                        new TextMessageContent("aaa", "bbb", null, null)))).isTrue();
+                        new TextMessageContent("aaa", "bbb", null, null, null, null)))).isTrue();
         assertThat(resolver.isSupported(
                 new MessageEvent(null, null, null, null, null, null,
-                        new ImageMessageContent("aaa", null, null)))).isFalse();
+                        new ImageMessageContent("aaa", null, null, null)))).isFalse();
         assertThat(resolver.isSupported(
                 new MemberJoinedEvent(null, null, null, null, null, null,
                         null))).isFalse();
@@ -44,7 +44,7 @@ class MessageContentArgumentResolverTest {
     @Test
     void resolve() {
         var resolver = new MessageContentArgumentResolver(TextMessageContent.class);
-        TextMessageContent textMessageContent = new TextMessageContent("aaa", "bbb", null, null);
+        TextMessageContent textMessageContent = new TextMessageContent("aaa", "bbb", null, null, null, null);
         assertThat(resolver.resolve(
                 "AAAA", new MessageEvent(
                         null, null, null, null, null, null,

--- a/spring-boot/line-bot-spring-boot-handler/src/test/java/com/linecorp/bot/spring/boot/handler/support/EventTestUtil.java
+++ b/spring-boot/line-bot-spring-boot-handler/src/test/java/com/linecorp/bot/spring/boot/handler/support/EventTestUtil.java
@@ -41,6 +41,8 @@ public final class EventTestUtil {
                         "id",
                         text,
                         null,
+                        null,
+                        null,
                         null
                 )
         );


### PR DESCRIPTION
(https://github.com/line/line-bot-sdk-java/pull/1072 failed, this change modifies some classes definition and test code.)



You can now send quote messages from your LINE Official Account and receive quote messages sent by users via webhook.
news: https://developers.line.biz/en/news/2023/09/14/send-and-receive-quote-messages-using-the-messaging-api/

1. Add response type for push/reply/mutlicast/narrowcast/broadcast API
    - `sentMessage` field is added in push and reply API
2. `sentMessage` field is added in push API's `ErrorResponse`
3. Add `quoteToken` and `quotedMessageId` in some Webhook events