### PR TITLE
feat: add mime type to blob content

### DIFF
--- a/clients/line-bot-client-base/src/main/java/com/linecorp/bot/client/base/BlobContent.java
+++ b/clients/line-bot-client-base/src/main/java/com/linecorp/bot/client/base/BlobContent.java
@@ -18,7 +18,9 @@ package com.linecorp.bot.client.base;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 
+import okhttp3.MediaType;
 import okhttp3.ResponseBody;
 
 public class BlobContent {
@@ -40,5 +42,13 @@ public class BlobContent {
      */
     public String string() throws IOException {
         return responseBody.string();
+    }
+
+    /**
+     * Returns the content type of the response.
+     */
+    public String mimeType() {
+        MediaType contentType = Objects.requireNonNull(responseBody.contentType());
+        return contentType.toString();
     }
 }

--- a/clients/line-bot-messaging-api-client/src/test/java/com/linecorp/bot/messaging/client/MessagingApiBlobClientExTest.java
+++ b/clients/line-bot-messaging-api-client/src/test/java/com/linecorp/bot/messaging/client/MessagingApiBlobClientExTest.java
@@ -103,7 +103,7 @@ public class MessagingApiBlobClientExTest {
         stubFor(get(urlEqualTo("/v2/bot/message/aaaa/content")).willReturn(
                 aResponse()
                         .withStatus(200)
-                        .withHeader("content-type", "application/octet-stream")
+                        .withHeader("content-type", "image/jpeg")
                         .withHeader("x-line-request-id", "ppp")
                         .withBody("JPG]]]]]]")));
 
@@ -114,6 +114,7 @@ public class MessagingApiBlobClientExTest {
         // Verify
         assertThat(result.requestId()).isEqualTo("ppp");
         assertThat(requireNonNull(result.body()).string()).isEqualTo("JPG]]]]]]");
+        assertThat(requireNonNull(result.body().mimeType())).isEqualTo("image/jpeg");
     }
 
     @Test


### PR DESCRIPTION
I've added a method to get the mime type of the blob content.
There is one in the version 6 sdk, so I thought it would be convenient to have one in version 7.

relate to #1096 