### PR TITLE
feat: add id to MessageContent

### DIFF
--- a/line-bot-webhook/src/main/java/com/linecorp/bot/webhook/model/MessageContent.java
+++ b/line-bot-webhook/src/main/java/com/linecorp/bot/webhook/model/MessageContent.java
@@ -55,5 +55,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
     visible = true
 )
 public interface MessageContent {
+    /** Get Message ID. */
+    String id();
 
 }


### PR DESCRIPTION
There is a getId() method in the MessageContent interface in version 6 sdk.
Which was very convenient.
Hope I can do the same in version 7.