### PR TITLE
Use published to run release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,8 @@
 name: Publish package to the Maven Central Repository
 on:
   release:
-    types: [ created ]
+    types: [ published ]
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
If we create release note as draft and publish it, current workflow doesn't run. We should use `published`. 
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release