### PR TITLE
Disable Javadoc lint warnings in Gradle build

### DIFF
--- a/buildSrc/src/main/kotlin/sdk.java-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/sdk.java-library.gradle.kts
@@ -60,6 +60,10 @@ tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
 }
 
+tasks.withType<Javadoc> {
+    (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:none", "-quiet")
+}
+
 tasks.withType(Test::class.java) {
     useJUnitPlatform()
     testLogging {


### PR DESCRIPTION
Most of our code is auto-generated, which typically includes Javadoc comments. Therefore, the Javadoc lint warnings that are triggered during the build process are not meaningful. This commit adds a configuration to the build.gradle.kts file to disable these warnings, reducing noise in the build output and making it easier to spot other potential issues.