### PR TITLE
Support converting enum to string for flex and template messages

### DIFF
--- a/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupAuthorityLevel.java
+++ b/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupAuthorityLevel.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.audience.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /** authority level */
 public enum AudienceGroupAuthorityLevel {
@@ -34,5 +35,15 @@ public enum AudienceGroupAuthorityLevel {
   PRIVATE,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case PUBLIC -> "PUBLIC";
+      case PRIVATE -> "PRIVATE";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupCreateRoute.java
+++ b/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupCreateRoute.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.audience.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * How the audience was created. One of: - &#x60;OA_MANAGER&#x60;: Audience created with [LINE
@@ -46,5 +47,17 @@ public enum AudienceGroupCreateRoute {
   AD_MANAGER,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case OA_MANAGER -> "OA_MANAGER";
+      case MESSAGING_API -> "MESSAGING_API";
+      case POINT_AD -> "POINT_AD";
+      case AD_MANAGER -> "AD_MANAGER";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupFailedType.java
+++ b/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupFailedType.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.audience.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /** Failed type */
 public enum AudienceGroupFailedType {
@@ -37,5 +38,16 @@ public enum AudienceGroupFailedType {
   NULL,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case AUDIENCE_GROUP_AUDIENCE_INSUFFICIENT -> "AUDIENCE_GROUP_AUDIENCE_INSUFFICIENT";
+      case INTERNAL_ERROR -> "INTERNAL_ERROR";
+      case NULL -> "null";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupJobFailedType.java
+++ b/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupJobFailedType.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.audience.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /** Failed type */
 public enum AudienceGroupJobFailedType {
@@ -34,5 +35,15 @@ public enum AudienceGroupJobFailedType {
   AUDIENCE_GROUP_AUDIENCE_INSUFFICIENT,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case INTERNAL_ERROR -> "INTERNAL_ERROR";
+      case AUDIENCE_GROUP_AUDIENCE_INSUFFICIENT -> "AUDIENCE_GROUP_AUDIENCE_INSUFFICIENT";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupJobStatus.java
+++ b/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupJobStatus.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.audience.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /** Job status */
 public enum AudienceGroupJobStatus {
@@ -40,5 +41,17 @@ public enum AudienceGroupJobStatus {
   FAILED,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case QUEUED -> "QUEUED";
+      case WORKING -> "WORKING";
+      case FINISHED -> "FINISHED";
+      case FAILED -> "FAILED";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupJobType.java
+++ b/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupJobType.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.audience.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /** Job Type */
 public enum AudienceGroupJobType {
@@ -31,5 +32,14 @@ public enum AudienceGroupJobType {
   DIFF_ADD,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case DIFF_ADD -> "DIFF_ADD";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupPermission.java
+++ b/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupPermission.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.audience.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /** Permission */
 public enum AudienceGroupPermission {
@@ -34,5 +35,15 @@ public enum AudienceGroupPermission {
   READ_WRITE,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case READ -> "READ";
+      case READ_WRITE -> "READ_WRITE";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupStatus.java
+++ b/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupStatus.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.audience.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /** Status */
 public enum AudienceGroupStatus {
@@ -46,5 +47,19 @@ public enum AudienceGroupStatus {
   ACTIVATING,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case IN_PROGRESS -> "IN_PROGRESS";
+      case READY -> "READY";
+      case FAILED -> "FAILED";
+      case EXPIRED -> "EXPIRED";
+      case INACTIVE -> "INACTIVE";
+      case ACTIVATING -> "ACTIVATING";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupType.java
+++ b/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/model/AudienceGroupType.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.audience.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /** Audience group type */
 public enum AudienceGroupType {
@@ -64,5 +65,25 @@ public enum AudienceGroupType {
   RICHMENU_CLICK,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case UPLOAD -> "UPLOAD";
+      case CLICK -> "CLICK";
+      case IMP -> "IMP";
+      case CHAT_TAG -> "CHAT_TAG";
+      case FRIEND_PATH -> "FRIEND_PATH";
+      case RESERVATION -> "RESERVATION";
+      case APP_EVENT -> "APP_EVENT";
+      case VIDEO_VIEW -> "VIDEO_VIEW";
+      case WEBTRAFFIC -> "WEBTRAFFIC";
+      case IMAGE_CLICK -> "IMAGE_CLICK";
+      case RICHMENU_IMP -> "RICHMENU_IMP";
+      case RICHMENU_CLICK -> "RICHMENU_CLICK";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/AgeDemographic.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/AgeDemographic.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /** Gets or Sets AgeDemographic */
 public enum AgeDemographic {
@@ -52,5 +53,21 @@ public enum AgeDemographic {
   AGE_50,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case AGE_15 -> "age_15";
+      case AGE_20 -> "age_20";
+      case AGE_25 -> "age_25";
+      case AGE_30 -> "age_30";
+      case AGE_35 -> "age_35";
+      case AGE_40 -> "age_40";
+      case AGE_45 -> "age_45";
+      case AGE_50 -> "age_50";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/AppTypeDemographic.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/AppTypeDemographic.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /** Gets or Sets AppTypeDemographic */
 public enum AppTypeDemographic {
@@ -34,5 +35,15 @@ public enum AppTypeDemographic {
   ANDROID,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case IOS -> "ios";
+      case ANDROID -> "android";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/AreaDemographic.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/AreaDemographic.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /** Gets or Sets AreaDemographic */
 public enum AreaDemographic {
@@ -385,5 +386,102 @@ public enum AreaDemographic {
   LAINNYA,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case HOKKAIDO -> "jp_01";
+      case AOMORI -> "jp_02";
+      case IWATE -> "jp_03";
+      case MIYAGI -> "jp_04";
+      case AKITA -> "jp_05";
+      case YAMAGATA -> "jp_06";
+      case FUKUSHIMA -> "jp_07";
+      case IBARAKI -> "jp_08";
+      case TOCHIGI -> "jp_09";
+      case GUNMA -> "jp_10";
+      case SAITAMA -> "jp_11";
+      case CHIBA -> "jp_12";
+      case TOKYO -> "jp_13";
+      case KANAGAWA -> "jp_14";
+      case NIIGATA -> "jp_15";
+      case TOYAMA -> "jp_16";
+      case ISHIKAWA -> "jp_17";
+      case FUKUI -> "jp_18";
+      case YAMANASHI -> "jp_19";
+      case NAGANO -> "jp_20";
+      case GIFU -> "jp_21";
+      case SHIZUOKA -> "jp_22";
+      case AICHI -> "jp_23";
+      case MIE -> "jp_24";
+      case SHIGA -> "jp_25";
+      case KYOTO -> "jp_26";
+      case OSAKA -> "jp_27";
+      case HYOUGO -> "jp_28";
+      case NARA -> "jp_29";
+      case WAKAYAMA -> "jp_30";
+      case TOTTORI -> "jp_31";
+      case SHIMANE -> "jp_32";
+      case OKAYAMA -> "jp_33";
+      case HIROSHIMA -> "jp_34";
+      case YAMAGUCHI -> "jp_35";
+      case TOKUSHIMA -> "jp_36";
+      case KAGAWA -> "jp_37";
+      case EHIME -> "jp_38";
+      case KOUCHI -> "jp_39";
+      case FUKUOKA -> "jp_40";
+      case SAGA -> "jp_41";
+      case NAGASAKI -> "jp_42";
+      case KUMAMOTO -> "jp_43";
+      case OITA -> "jp_44";
+      case MIYAZAKI -> "jp_45";
+      case KAGOSHIMA -> "jp_46";
+      case OKINAWA -> "jp_47";
+      case TAIPEI_CITY -> "tw_01";
+      case NEW_TAIPEI_CITY -> "tw_02";
+      case TAOYUAN_CITY -> "tw_03";
+      case TAICHUNG_CITY -> "tw_04";
+      case TAINAN_CITY -> "tw_05";
+      case KAOHSIUNG_CITY -> "tw_06";
+      case KEELUNG_CITY -> "tw_07";
+      case HSINCHU_CITY -> "tw_08";
+      case CHIAYI_CITY -> "tw_09";
+      case HSINCHU_COUNTY -> "tw_10";
+      case MIAOLI_COUNTY -> "tw_11";
+      case CHANGHUA_COUNTY -> "tw_12";
+      case NANTOU_COUNTY -> "tw_13";
+      case YUNLIN_COUNTY -> "tw_14";
+      case CHIAYI_COUNTY -> "tw_15";
+      case PINGTUNG_COUNTY -> "tw_16";
+      case YILAN_COUNTY -> "tw_17";
+      case HUALIEN_COUNTY -> "tw_18";
+      case TAITUNG_COUNTY -> "tw_19";
+      case PENGHU_COUNTY -> "tw_20";
+      case KINMEN_COUNTY -> "tw_21";
+      case LIENCHIANG_COUNTY -> "tw_22";
+      case BANGKOK -> "th_01";
+      case PATTAYA -> "th_02";
+      case NORTHERN -> "th_03";
+      case CENTRAL -> "th_04";
+      case SOUTHERN -> "th_05";
+      case EASTERN -> "th_06";
+      case NORTHEASTERN -> "th_07";
+      case WESTERN -> "th_08";
+      case BALI -> "id_01";
+      case BANDUNG -> "id_02";
+      case BANJARMASIN -> "id_03";
+      case JABODETABEK -> "id_04";
+      case MAKASSAR -> "id_05";
+      case MEDAN -> "id_06";
+      case PALEMBANG -> "id_07";
+      case SAMARINDA -> "id_08";
+      case SEMARANG -> "id_09";
+      case SURABAYA -> "id_10";
+      case YOGYAKARTA -> "id_11";
+      case LAINNYA -> "id_12";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexBoxBorderWidth.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexBoxBorderWidth.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Width of box border. This is only for &#x60;borderWidth&#x60; in FlexBox. A value of none means
@@ -49,5 +50,19 @@ public enum FlexBoxBorderWidth {
   BOLD,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case NONE -> "none";
+      case LIGHT -> "light";
+      case NORMAL -> "normal";
+      case MEDIUM -> "medium";
+      case SEMI_BOLD -> "semi-bold";
+      case BOLD -> "bold";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexBoxCornerRadius.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexBoxCornerRadius.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Radius at the time of rounding the corners of the box. This is only for &#x60;cornerRadius&#x60;
@@ -53,5 +54,20 @@ public enum FlexBoxCornerRadius {
   XXL,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case NONE -> "none";
+      case XS -> "xs";
+      case SM -> "sm";
+      case MD -> "md";
+      case LG -> "lg";
+      case XL -> "xl";
+      case XXL -> "xxl";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexBoxPadding.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexBoxPadding.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Padding can be specified in pixels, percentage (to the parent box width) or with a keyword.
@@ -52,5 +53,20 @@ public enum FlexBoxPadding {
   XXL,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case NONE -> "none";
+      case XS -> "xs";
+      case SM -> "sm";
+      case MD -> "md";
+      case LG -> "lg";
+      case XL -> "xl";
+      case XXL -> "xxl";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexBoxSpacing.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexBoxSpacing.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * You can specify the minimum space between two components with the &#x60;spacing&#x60; property of
@@ -53,5 +54,20 @@ public enum FlexBoxSpacing {
   XXL,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case NONE -> "none";
+      case XS -> "xs";
+      case SM -> "sm";
+      case MD -> "md";
+      case LG -> "lg";
+      case XL -> "xl";
+      case XXL -> "xxl";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexIconSize.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexIconSize.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * You can set the width of an Flex icon component with the &#x60;size&#x60; property, in pixels, as
@@ -61,5 +62,23 @@ public enum FlexIconSize {
   _5XL,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case XXS -> "xxs";
+      case XS -> "xs";
+      case SM -> "sm";
+      case MD -> "md";
+      case LG -> "lg";
+      case XL -> "xl";
+      case XXL -> "xxl";
+      case _3XL -> "3xl";
+      case _4XL -> "4xl";
+      case _5XL -> "5xl";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexImageSize.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexImageSize.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * You can set the width of an Flex image component with the &#x60;size&#x60; property, in pixels,
@@ -64,5 +65,24 @@ public enum FlexImageSize {
   FULL,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case XXS -> "xxs";
+      case XS -> "xs";
+      case SM -> "sm";
+      case MD -> "md";
+      case LG -> "lg";
+      case XL -> "xl";
+      case XXL -> "xxl";
+      case _3XL -> "3xl";
+      case _4XL -> "4xl";
+      case _5XL -> "5xl";
+      case FULL -> "full";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexMargin.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexMargin.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * You can specify the minimum space before a child component with the &#x60;margin&#x60; property
@@ -52,5 +53,20 @@ public enum FlexMargin {
   XXL,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case NONE -> "none";
+      case XS -> "xs";
+      case SM -> "sm";
+      case MD -> "md";
+      case LG -> "lg";
+      case XL -> "xl";
+      case XXL -> "xxl";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexOffset.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexOffset.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * You can specify the offset of a component with the &#x60;offset*&#x60; property, in pixels or
@@ -54,5 +55,20 @@ public enum FlexOffset {
   XXL,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case NONE -> "none";
+      case XS -> "xs";
+      case SM -> "sm";
+      case MD -> "md";
+      case LG -> "lg";
+      case XL -> "xl";
+      case XXL -> "xxl";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexSpanSize.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexSpanSize.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Font size in the &#x60;size&#x60; property of the Flex span component. You can specify the size
@@ -61,5 +62,23 @@ public enum FlexSpanSize {
   _5XL,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case XXS -> "xxs";
+      case XS -> "xs";
+      case SM -> "sm";
+      case MD -> "md";
+      case LG -> "lg";
+      case XL -> "xl";
+      case XXL -> "xxl";
+      case _3XL -> "3xl";
+      case _4XL -> "4xl";
+      case _5XL -> "5xl";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexTextFontSize.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/FlexTextFontSize.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Font size in the &#x60;size&#x60; property of the Flex text component. You can specify the size
@@ -61,5 +62,23 @@ public enum FlexTextFontSize {
   _5XL,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case XXS -> "xxs";
+      case XS -> "xs";
+      case SM -> "sm";
+      case MD -> "md";
+      case LG -> "lg";
+      case XL -> "xl";
+      case XXL -> "xxl";
+      case _3XL -> "3xl";
+      case _4XL -> "4xl";
+      case _5XL -> "5xl";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/GenderDemographic.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/GenderDemographic.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /** Gets or Sets GenderDemographic */
 public enum GenderDemographic {
@@ -34,5 +35,15 @@ public enum GenderDemographic {
   FEMALE,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case MALE -> "male";
+      case FEMALE -> "female";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/QuotaType.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/QuotaType.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /** One of the following values to indicate whether a target limit is set or not. */
 public enum QuotaType {
@@ -34,5 +35,15 @@ public enum QuotaType {
   LIMITED,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case NONE -> "none";
+      case LIMITED -> "limited";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/RichMenuBatchProgressPhase.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/RichMenuBatchProgressPhase.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * The current status. One of: &#x60;ongoing&#x60;: Rich menu batch control is in progress.
@@ -42,5 +43,16 @@ public enum RichMenuBatchProgressPhase {
   FAILED,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case ONGOING -> "ongoing";
+      case SUCCEEDED -> "succeeded";
+      case FAILED -> "failed";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/SubscriptionPeriodDemographic.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/SubscriptionPeriodDemographic.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /** Gets or Sets SubscriptionPeriodDemographic */
 public enum SubscriptionPeriodDemographic {
@@ -43,5 +44,18 @@ public enum SubscriptionPeriodDemographic {
   DAY_365,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case DAY_7 -> "day_7";
+      case DAY_30 -> "day_30";
+      case DAY_90 -> "day_90";
+      case DAY_180 -> "day_180";
+      case DAY_365 -> "day_365";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/TemplateImageAspectRatio.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/TemplateImageAspectRatio.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Aspect ratio of the image. This is only for the &#x60;imageAspectRatio&#x60; in ButtonsTemplate.
@@ -37,5 +38,15 @@ public enum TemplateImageAspectRatio {
   SQUARE,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case RECTANGLE -> "rectangle";
+      case SQUARE -> "square";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/TemplateImageSize.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/model/TemplateImageSize.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Size of the image. This is only for the &#x60;imageSize&#x60; in ButtonsTemplate. Specify one of
@@ -40,5 +41,15 @@ public enum TemplateImageSize {
   CONTAIN,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case COVER -> "cover";
+      case CONTAIN -> "contain";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-liff-client/src/main/java/com/linecorp/bot/liff/model/LiffBotPrompt.java
+++ b/clients/line-liff-client/src/main/java/com/linecorp/bot/liff/model/LiffBotPrompt.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.liff.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Specify the setting for bot link feature with one of the following values: &#x60;normal&#x60;:
@@ -43,5 +44,16 @@ public enum LiffBotPrompt {
   NONE,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case NORMAL -> "normal";
+      case AGGRESSIVE -> "aggressive";
+      case NONE -> "none";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/clients/line-liff-client/src/main/java/com/linecorp/bot/liff/model/LiffScope.java
+++ b/clients/line-liff-client/src/main/java/com/linecorp/bot/liff/model/LiffScope.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.liff.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Array of scopes required for some LIFF SDK methods to function. The default value is
@@ -43,5 +44,17 @@ public enum LiffScope {
   CHAT_MESSAGE_WRITE,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case OPENID -> "openid";
+      case EMAIL -> "email";
+      case PROFILE -> "profile";
+      case CHAT_MESSAGE_WRITE -> "chat_message.write";
+
+      default -> "UNDEFINED";
+    };
+  }
 }

--- a/generator/src/main/resources/line-java-codegen/model/enum.pebble
+++ b/generator/src/main/resources/line-java-codegen/model/enum.pebble
@@ -1,5 +1,6 @@
 {# @pebvariable name="model" type="org.openapitools.codegen.CodegenModel" -#}
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * {{ model.description | escape }}{% if not model.description %}Gets or Sets {{model.name}}{% endif %}
@@ -17,5 +18,18 @@ public enum {{model.classname}} {
     {% endfor %}
 {% endif %}
     @JsonEnumDefaultValue
-    UNDEFINED
+    UNDEFINED;
+
+
+    @JsonValue
+    public String toValue() {
+        return switch (this) {
+        {% if model.allowableValues != null %}
+            {% for enumVar in model.allowableValues.get("enumVars") -%}
+            case {{enumVar.name}} -> {{enumVar.value}};
+            {% endfor %}
+        {% endif %}
+            default -> "UNDEFINED";
+        };
+    }
 }

--- a/line-bot-webhook/src/main/java/com/linecorp/bot/webhook/model/EventMode.java
+++ b/line-bot-webhook/src/main/java/com/linecorp/bot/webhook/model/EventMode.java
@@ -24,6 +24,7 @@ package com.linecorp.bot.webhook.model;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /** Channel state. */
 public enum EventMode {
@@ -34,5 +35,15 @@ public enum EventMode {
   STANDBY,
 
   @JsonEnumDefaultValue
-  UNDEFINED
+  UNDEFINED;
+
+  @JsonValue
+  public String toValue() {
+    return switch (this) {
+      case ACTIVE -> "active";
+      case STANDBY -> "standby";
+
+      default -> "UNDEFINED";
+    };
+  }
 }


### PR DESCRIPTION
https://github.com/line/line-openapi/pull/46 defines keywords for flex messages and template messages.
In addition to keywords, template messages and flex messages can specify values in percentages or pixels.
(e.g. image size in flex message: https://developers.line.biz/en/docs/messaging-api/flex-message-layout/#image-size)
This just supports converting enum to string value for bot sdk users, and users can select one of raw value or enum.toValue().



Resolve https://github.com/line/line-bot-sdk-java/issues/1155