### PR TITLE
Return empty list when original content is null

### DIFF
--- a/clients/line-bot-insight-client/src/main/java/com/linecorp/bot/insight/client/InsightClientException.java
+++ b/clients/line-bot-insight-client/src/main/java/com/linecorp/bot/insight/client/InsightClientException.java
@@ -50,6 +50,9 @@ public class InsightClientException extends AbstractLineClientException {
     }
 
     public List<ErrorDetail> getDetails() {
+        if (details == null) {
+            return Collections.emptyList();
+        }
         return Collections.unmodifiableList(details);
     }
 }

--- a/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/client/ManageAudienceClientException.java
+++ b/clients/line-bot-manage-audience-client/src/main/java/com/linecorp/bot/audience/client/ManageAudienceClientException.java
@@ -50,6 +50,9 @@ public class ManageAudienceClientException extends AbstractLineClientException {
     }
 
     public List<ErrorDetail> getDetails() {
+        if (details == null) {
+            return Collections.emptyList();
+        }
         return Collections.unmodifiableList(details);
     }
 }

--- a/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/client/MessagingApiClientException.java
+++ b/clients/line-bot-messaging-api-client/src/main/java/com/linecorp/bot/messaging/client/MessagingApiClientException.java
@@ -57,10 +57,16 @@ public class MessagingApiClientException extends AbstractLineClientException {
     }
 
     public List<ErrorDetail> getDetails() {
+        if (details == null) {
+            return Collections.emptyList();
+        }
         return Collections.unmodifiableList(details);
     }
 
     public List<SentMessage> getSentMessages() {
+        if (sentMessages == null) {
+            return Collections.emptyList();
+        }
         return Collections.unmodifiableList(sentMessages);
     }
 }


### PR DESCRIPTION
When the list that can be obtained at the time of error is null, it becomes NPE. This change returns an empty list when null, to prevent unintended NPE.

Resolve #1223