### PR TITLE
Use the latest submodules when generating code is hooked

### DIFF
--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Update submodules
+        run: git submodule update --remote --recursive
       - name: Set up Java
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
When we run `generate-code.yml` manually, this doesn't generated code when it's before line-openapi is not updated yet.
This change fixes it. Note line-bot-sdk-php and line-bot-sdk-nodejs do this. (python, java, and go don't do this yet)