### PR TITLE
fix(deps): update dependency org.assertj:assertj-core to v3.26.0

### DIFF
--- a/clients/line-channel-access-token-client/src/test/java/com/linecorp/bot/oauth/client/ChannelAccessTokenClientExTest.java
+++ b/clients/line-channel-access-token-client/src/test/java/com/linecorp/bot/oauth/client/ChannelAccessTokenClientExTest.java
@@ -114,10 +114,10 @@ public class ChannelAccessTokenClientExTest {
 
         // Do
         final CompletionException actualException =
-                catchThrowableOfType(() -> target.issueChannelToken("client_credentials",
+                catchThrowableOfType(CompletionException.class,
+                        () -> target.issueChannelToken("client_credentials",
                                 "clientId",
-                                "clientSecret").join(),
-                        CompletionException.class);
+                                "clientSecret").join());
 
         // Verify
         verify(

--- a/gradle/libraries.versions.toml
+++ b/gradle/libraries.versions.toml
@@ -2,7 +2,7 @@
 retrofit2 = "2.11.0"
 jjwt = "0.12.5"
 jackson = "2.17.1"
-assertj = "3.25.3"
+assertj = "3.26.0"
 junit = "5.10.2"
 slf4j = "2.0.13"
 mockito = "5.12.0"


### PR DESCRIPTION
https://github.com/line/line-bot-sdk-java/pull/1338 failed because the former of `catchThrowableOfType` has been deprecated. We should use the latter.
```java
    @java.lang.Deprecated
    public static <THROWABLE extends java.lang.Throwable> THROWABLE catchThrowableOfType(org.assertj.core.api.ThrowableAssert.ThrowingCallable shouldRaiseThrowable, java.lang.Class<THROWABLE> type) { ... }

    public static <THROWABLE extends java.lang.Throwable> THROWABLE catchThrowableOfType(java.lang.Class<THROWABLE> type, org.assertj.core.api.ThrowableAssert.ThrowingCallable shouldRaiseThrowable) { ... }
```