### PR TITLE
Update java-socks-proxy-server

### DIFF
--- a/clients/line-bot-client-base/src/test/java/com/linecorp/bot/client/base/ApiClientBuilderTest.java
+++ b/clients/line-bot-client-base/src/test/java/com/linecorp/bot/client/base/ApiClientBuilderTest.java
@@ -79,8 +79,8 @@ class ApiClientBuilderTest {
         int socksPort = 9020;
 
         SocksServer socksServer = new SocksServer(socksPort)
-                .setAuthenticator(new DefaultAuthenticator())
-                .start();
+                .setAuthenticator(new DefaultAuthenticator());
+        socksServer.start();
 
         WireMockServer wireMockServer = new WireMockServer(wireMockConfig().dynamicPort());
         wireMockServer.start();

--- a/gradle/libraries.versions.toml
+++ b/gradle/libraries.versions.toml
@@ -46,7 +46,7 @@ mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 wiremock = { group = "org.wiremock", name = "wiremock-standalone", version = "3.9.1" }
 test-arranger = { module = "com.ocadotechnology.gembus:test-arranger", version = "1.5.7.1" }
-socks-proxy-server = { module = "com.github.bbottema:java-socks-proxy-server", version = "4.1.1" }
+socks-proxy-server = { module = "com.github.bbottema:java-socks-proxy-server", version = "4.1.2" }
 littleproxy = { module = "xyz.rogfam:littleproxy", version = "2.2.0" }
 
 [bundles]


### PR DESCRIPTION
In java-socks-proxy-server v4.1.2, the return value of start() has been changed to null. 
https://github.com/bbottema/java-socks-proxy-server/commit/e1286c26c323b83810cfb677e35c4aafc5508ac4#diff-b1e6e3096f697b3fa6365676e216d916a266831015b0593304abfb6b00adcd74R45

Therefore, we need to fix the tests and update their version manually.

Close https://github.com/line/line-bot-sdk-java/pull/1435