### PR TITLE
Disable defaultImpl for newly added classes

### DIFF
--- a/generator/src/main/resources/line-java-codegen/model/interface.pebble
+++ b/generator/src/main/resources/line-java-codegen/model/interface.pebble
@@ -14,7 +14,12 @@
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.PROPERTY,
     property = "{{model.discriminator.propertyName}}",
+    {# Unknown{{className}} is not auto-generated, so the defaultImpl for newly added classes needs to be disabled. #}
+    {% if ["Event", "MessageContent", "Message", "Action", "DemographicFilter", "FlexBoxBackground", "FlexComponent",
+       "FlexContainer", "ImagemapAction", "Mentionee", "ModuleContent", "Recipient", "RichMenuBatchOperation",
+       "Source", "Template", "ThingsContent"] contains model.classname %}
     defaultImpl = Unknown{{model.classname}}.class,
+    {% endif %}
     visible = true
 )
 public interface {{model.classname}} {


### PR DESCRIPTION
## Changes

The code automatically generates a default implementation specifying a class named `Unknown{{className}}` for interface types such as the Event class. However, the `Unknown{{className}}` type itself **is not auto-generated**. 
This causes inconvenience when defining new interface types in OpenAPI. 

This PR modifies the code to enable `defaultImpl` only for currently existing interface types and disables it for any classes that will be added in the future.