### PR TITLE
Allow to git tag containing `v` as prefix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,7 @@ jobs:
           else
             VERSION=${{ github.event.release.tag_name }}
           fi
+          VERSION=${VERSION#v}
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Publish package


### PR DESCRIPTION
We've decided to specify git tag versions with a `v` prefix for all bot-sdk repositories. This is to apply the same rule across all repositories and reduce mistakes.

In the case of line-bot-sdk-java, specifying the `v` prefix is not an issue as long as it is removed during publishing. This change supports it.