### PR TITLE
Pin commit hash of github actions to avoid supply chain attacks

### DIFF
--- a/.github/workflows/check-eol-newrelease.yml
+++ b/.github/workflows/check-eol-newrelease.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run EoL & NewRelease check
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const checkEolAndNewReleases = require('.github/scripts/check-eol-newrelease.cjs');

--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-issue-stale: 14
           days-before-issue-close: 0

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -43,10 +43,10 @@ jobs:
     needs: validate-input
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Fetch Latest Release
         id: get-latest-release
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const latestRelease = await github.rest.repos.getLatestRelease({
@@ -62,7 +62,7 @@ jobs:
 
       - name: Calculate New Version
         id: calculate-version
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const latestTag = '${{ steps.get-latest-release.outputs.latest_tag }}';
@@ -83,7 +83,7 @@ jobs:
 
       - name: Generate Release Notes
         id: generate-release-notes
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const { data: releaseNotes } = await github.rest.repos.generateReleaseNotes({

--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -13,18 +13,18 @@ jobs:
 
     steps:
       - name: Setup
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
       - name: Update submodules
         run: git submodule update --remote --recursive
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: 'temurin'
           java-version: 17
           architecture: x64
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       - name: Generate code
         run: |
           python generate-code.py

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,6 +45,8 @@ jobs:
 
   pinact:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run pinact

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,12 +27,12 @@ jobs:
           - '21'
     steps:
       - name: actions/setup-java@v3 (JDK ${{ matrix.java }})
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           architecture: x64
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
       - run: |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -42,3 +42,12 @@ jobs:
       - run: cd generator && mvn package && cd ..
       - run: python3 generate-code.py
       - run: ./gradlew build
+
+  pinact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Run pinact
+        uses: suzuki-shunsuke/pinact-action@a6896d13d22e2bf108a78b0c52d3f867c1f41b34 # v0.2.1
+        with:
+          skip_push: "true"

--- a/.github/workflows/pom-validation.yml
+++ b/.github/workflows/pom-validation.yml
@@ -11,12 +11,12 @@ jobs:
         java: [ '17' ] # We want to test on LTSs.
     steps:
     - name: actions/setup-java@v3 (JDK ${{ matrix.java }})
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
         architecture: x64
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         submodules: true
     - run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -58,7 +58,7 @@ jobs:
 
       - name: Create GitHub Issue on Failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "timezone": "Asia/Tokyo",
   "automerge": true,


### PR DESCRIPTION
## Changes
To avoid supply chain attacks, specify actions in GitHub Actions workflows using commit hashes instead of version numbers. Pinact-action will fail the CI job if this is not done. Renovate already supports updates in the commit hash state, so there is no issue.

## References
- https://github.com/suzuki-shunsuke/pinact-action
  - does pinact-action verify the checksum of the version of aqua it is using? Yes!: 
- https://github.com/suzuki-shunsuke/pinact

## Other repositories
- line/line-bot-sdk-python https://github.com/line/line-bot-sdk-python/pull/772
- line/line-bot-sdk-php https://github.com/line/line-bot-sdk-php/pull/680
- line/line-bot-sdk-nodejs https://github.com/line/line-bot-sdk-nodejs/pull/1201
- line/line-bot-sdk-java https://github.com/line/line-bot-sdk-java/pull/1576
- line/line-bot-sdk-go https://github.com/line/line-bot-sdk-go/pull/555
- line/line-bot-sdk-ruby https://github.com/line/line-bot-sdk-ruby/pull/405
- line/line-openapi https://github.com/line/line-openapi/pull/90