### PR TITLE
Grant minimum permissions to github acitons workflow jobs

### DIFF
--- a/.github/workflows/check-eol-newrelease.yml
+++ b/.github/workflows/check-eol-newrelease.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   check-eol-newrelease:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/check-eol-newrelease.yml
+++ b/.github/workflows/check-eol-newrelease.yml
@@ -25,8 +25,8 @@ jobs:
               languageName: 'Java',
               eolJsonUrl: 'https://endoflife.date/api/eclipse-temurin.json',
               eolViewUrl: 'https://endoflife.date/eclipse-temurin',
-              eolLookbackDays: 100,
-              newReleaseThresholdDays: 100,
+              eolLookbackDays: 1000,
+              newReleaseThresholdDays: 1000,
               ltsOnly: true,
               retryCount: 3,
               retryIntervalSec: 30

--- a/.github/workflows/check-eol-newrelease.yml
+++ b/.github/workflows/check-eol-newrelease.yml
@@ -25,8 +25,8 @@ jobs:
               languageName: 'Java',
               eolJsonUrl: 'https://endoflife.date/api/eclipse-temurin.json',
               eolViewUrl: 'https://endoflife.date/eclipse-temurin',
-              eolLookbackDays: 1000,
-              newReleaseThresholdDays: 1000,
+              eolLookbackDays: 100,
+              newReleaseThresholdDays: 100,
               ltsOnly: true,
               retryCount: 3,
               retryIntervalSec: 30

--- a/.github/workflows/check-eol-newrelease.yml
+++ b/.github/workflows/check-eol-newrelease.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+    if: github.repository == 'line/line-bot-sdk-java'
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+    if: github.repository == 'line/line-bot-sdk-java'
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   validate-input:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Validate Acknowledgement
         if: ${{ github.event.inputs.acknowledge_draft != 'Yes' }}
@@ -41,7 +42,8 @@ jobs:
   create-draft-release:
     runs-on: ubuntu-latest
     needs: validate-input
-
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Fetch Latest Release

--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Setup
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,6 +19,8 @@ jobs:
     name: test (JDK ${{ matrix.java }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pom-validation.yml
+++ b/.github/workflows/pom-validation.yml
@@ -5,6 +5,8 @@ jobs:
     name: test (JDK ${{ matrix.java }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
## Changes
Granting the minimum necessary permissions is always a good practice. There might be cases where permissions are insufficient, but since errors are very clear, I believe we can add them when a failure occurs.

After merging, I will change the default of the GITHUB_ACTIONS token from read + write to read only. Then, I will run as many workflows as possible (including publish) to verify their operation.

reference: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#overview