### PR TITLE
Require more jobs in merge queue

### DIFF
--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -1,11 +1,12 @@
 name: Generate code and open pull request
 
 on:
-  workflow_dispatch:
-  pull_request:
   push:
     branches:
       - master
+  pull_request:
+  merge_group:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/pom-validation.yml
+++ b/.github/workflows/pom-validation.yml
@@ -1,5 +1,10 @@
 name: pom validation
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
 jobs:
   test:
     name: test (JDK ${{ matrix.java }})


### PR DESCRIPTION
To re-enable the merge queue, this change adds merge_group to several jobs.
job for test has already this config: https://github.com/line/line-bot-sdk-java/blob/87df6c8d05abd9d5b624e3095a0c3170c130cddf/.github/workflows/gradle.yml#L14