### PR TITLE
Replace dependency xyz.rogfam:littleproxy with io.github.littleproxy:littleproxy 2.4.0

### DIFF
--- a/gradle/libraries.versions.toml
+++ b/gradle/libraries.versions.toml
@@ -49,7 +49,7 @@ mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.
 wiremock = { group = "org.wiremock", name = "wiremock-standalone", version = "3.12.1" }
 test-arranger = { module = "com.ocadotechnology.gembus:test-arranger", version = "1.5.7.1" }
 socks-proxy-server = { module = "com.github.bbottema:java-socks-proxy-server", version = "4.1.2" }
-littleproxy = { module = "xyz.rogfam:littleproxy", version = "2.2.0" }
+littleproxy = { module = "io.github.littleproxy:littleproxy", version = "2.4.0" }
 
 [bundles]
 retrofit2 = ["retrofit2-converter-jackson", "retrofit2-retrofit"]


### PR DESCRIPTION
renovate throws error to replace `xyz.rogfam:littleproxy` with `io.github.littleproxy:littleproxy 2.4.0`. This change fixes it manually.

(See `warn` as log level in https://developer.mend.io/github/line/line-bot-sdk-java/-/job/b6c1fbc6-2bf4-495b-b3de-ff41ea0eaabb)