### PR TITLE
Fix pebble for array-type query parameter

### DIFF
--- a/generator/src/main/resources/line-java-codegen/api_test.pebble
+++ b/generator/src/main/resources/line-java-codegen/api_test.pebble
@@ -29,6 +29,7 @@ import com.linecorp.bot.client.base.UploadFile;
 import java.net.URI;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 {% if classname == "MessagingApiClient" or classname == "MessagingApiBlobClient" %}
 import com.linecorp.bot.messaging.model.TextMessage;
@@ -96,7 +97,12 @@ public class {{classname}}Test {
         {% if param.isFile %}
             UploadFile {{param.paramName}} = UploadFile.fromString("HELLO_FILE", "text/plain");
         {% else %}
-            {{param.dataType}} {{param.paramName}} = Arranger.some({{param.dataType}}.class{% if classname == "MessagingApiClient" or classname == "MessagingApiBlobClient" %}, Map.of("message", () -> new TextMessage("hello"), "recipient", () -> null, "filter", () -> null){% endif %});
+            {{param.dataType}} {{param.paramName}} =
+            {% if param.isArray %}
+            Arranger.someObjects({{param.items.dataType}}.class, 1{% if classname == "MessagingApiClient" or classname == "MessagingApiBlobClient" %}, Map.of("message", () -> new TextMessage("hello"), "recipient", () -> null, "filter", () -> null){% endif %}).collect(Collectors.toSet());
+            {% else %}
+            Arranger.some({{param.dataType}}.class{% if classname == "MessagingApiClient" or classname == "MessagingApiBlobClient" %}, Map.of("message", () -> new TextMessage("hello"), "recipient", () -> null, "filter", () -> null){% endif %});
+            {% endif %}
         {% endif %}
     {% endfor %}
 

--- a/generator/src/main/resources/line-java-codegen/macros/api_param.pebble
+++ b/generator/src/main/resources/line-java-codegen/macros/api_param.pebble
@@ -1,7 +1,8 @@
 {%- macro api_param(param, op) -%}
 {#- @pebvariable name="param" type="org.openapitools.codegen.CodegenParameter" -#}
 {#- @pebvariable name="op" type="org.openapitools.codegen.CodegenOperation" -#}
-{%- if param.isQueryParam %}@Query("{{param.baseName}}") {% if param.collectionFormat %}{{ abort() }}{% else %}{{ param.dataType }}{% endif %} {{ param.paramName }}
+{%- if param.isQueryParam %}
+    @Query("{{param.baseName}}") {{ param.dataType }} {{ param.paramName }}
 {%- elseif param.isPathParam -%}
 @Path("{{param.baseName}}") {{param.dataType}} {{param.paramName}}
 {%- elseif param.isHeaderParam -%}


### PR DESCRIPTION
## Description
This PR addresses a modification to the generator responsible for producing the Java SDK from OpenAPI definitions. Specifically, it introduces support for query parameters that include arrays.

## Changes
Enhanced the generator to handle array-type query parameters.

Here is an example of how such an API call might look in a shell script:
```sh
curl -X GET "https://api.line.me/v2/bot/example?param=value1&param=value2"
```

## Note
Currently, there are no endpoints that utilize such parameters. However, this update is a preparatory step for future API enhancements.