### PR TITLE
Add option to skip signature verification

### DIFF
--- a/line-bot-parser/src/main/java/com/linecorp/bot/parser/FixedSkipSignatureVerificationSupplier.java
+++ b/line-bot-parser/src/main/java/com/linecorp/bot/parser/FixedSkipSignatureVerificationSupplier.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.parser;
+
+public class FixedSkipSignatureVerificationSupplier implements SkipSignatureVerificationSupplier {
+    private final boolean fixedValue;
+
+    public FixedSkipSignatureVerificationSupplier(boolean fixedValue) {
+        this.fixedValue = fixedValue;
+    }
+
+    public static FixedSkipSignatureVerificationSupplier of(boolean fixedValue) {
+        return new FixedSkipSignatureVerificationSupplier(fixedValue);
+    }
+
+    @Override
+    public boolean getAsBoolean() {
+        return fixedValue;
+    }
+}

--- a/line-bot-parser/src/main/java/com/linecorp/bot/parser/LineSignatureValidator.java
+++ b/line-bot-parser/src/main/java/com/linecorp/bot/parser/LineSignatureValidator.java
@@ -74,5 +74,4 @@ public class LineSignatureValidator implements SignatureValidator {
             throw new IllegalStateException(e);
         }
     }
-
 }

--- a/line-bot-parser/src/main/java/com/linecorp/bot/parser/SkipSignatureVerificationSupplier.java
+++ b/line-bot-parser/src/main/java/com/linecorp/bot/parser/SkipSignatureVerificationSupplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.bot.parser;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * Special {@link BooleanSupplier} for Skip Signature Verification.
+ *
+ * <p>You can implement it to return whether to skip signature verification.
+ */
+@FunctionalInterface
+public interface SkipSignatureVerificationSupplier extends BooleanSupplier {
+}

--- a/line-bot-parser/src/main/java/com/linecorp/bot/parser/WebhookParser.java
+++ b/line-bot-parser/src/main/java/com/linecorp/bot/parser/WebhookParser.java
@@ -34,14 +34,17 @@ public class WebhookParser {
 
     private final ObjectMapper objectMapper = ModelObjectMapper.createNewObjectMapper();
     private final SignatureValidator signatureValidator;
+    private final SkipSignatureVerificationSupplier skipSignatureVerificationSupplier;
 
     /**
      * Creates a new instance.
      *
      * @param signatureValidator LINE messaging API's signature validator
      */
-    public WebhookParser(SignatureValidator signatureValidator) {
+    public WebhookParser(SignatureValidator signatureValidator,
+                         SkipSignatureVerificationSupplier skipSignatureVerificationSupplier) {
         this.signatureValidator = requireNonNull(signatureValidator);
+        this.skipSignatureVerificationSupplier = requireNonNull(skipSignatureVerificationSupplier);
     }
 
     /**
@@ -62,7 +65,8 @@ public class WebhookParser {
             log.debug("got: {}", new String(payload, StandardCharsets.UTF_8));
         }
 
-        if (!signatureValidator.validateSignature(payload, signature)) {
+        if (!skipSignatureVerificationSupplier.getAsBoolean()
+            && !signatureValidator.validateSignature(payload, signature)) {
             throw new WebhookParseException("Invalid API signature");
         }
 

--- a/spring-boot/line-bot-spring-boot-client/src/main/java/com/linecorp/bot/spring/boot/core/properties/LineBotProperties.java
+++ b/spring-boot/line-bot-spring-boot-client/src/main/java/com/linecorp/bot/spring/boot/core/properties/LineBotProperties.java
@@ -84,7 +84,12 @@ public record LineBotProperties(
          * Write timeout in milliseconds.
          */
         @DefaultValue("10s")
-        @Valid @NotNull Duration writeTimeout
+        @Valid @NotNull Duration writeTimeout,
+
+        /*
+         * Skip signature verification of webhooks.
+         */
+        boolean skipSignatureVerification
 ) {
     public enum ChannelTokenSupplyMode {
         /**

--- a/spring-boot/line-bot-spring-boot-client/src/test/java/com/linecorp/bot/spring/boot/core/properties/BotPropertiesValidatorTest.java
+++ b/spring-boot/line-bot-spring-boot-client/src/test/java/com/linecorp/bot/spring/boot/core/properties/BotPropertiesValidatorTest.java
@@ -55,7 +55,8 @@ public class BotPropertiesValidatorTest {
                 URI.create("https://manager.line.biz/"),
                 Duration.ofSeconds(10),
                 Duration.ofSeconds(10),
-                Duration.ofSeconds(10)
+                Duration.ofSeconds(10),
+                false
         );
     }
 

--- a/spring-boot/line-bot-spring-boot-web/src/main/java/com/linecorp/bot/spring/boot/web/configuration/LineBotWebBeans.java
+++ b/spring-boot/line-bot-spring-boot-web/src/main/java/com/linecorp/bot/spring/boot/web/configuration/LineBotWebBeans.java
@@ -18,12 +18,15 @@ package com.linecorp.bot.spring.boot.web.configuration;
 
 import java.nio.charset.StandardCharsets;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
 
+import com.linecorp.bot.parser.FixedSkipSignatureVerificationSupplier;
 import com.linecorp.bot.parser.LineSignatureValidator;
+import com.linecorp.bot.parser.SkipSignatureVerificationSupplier;
 import com.linecorp.bot.parser.WebhookParser;
 import com.linecorp.bot.spring.boot.core.properties.LineBotProperties;
 import com.linecorp.bot.spring.boot.web.argument.support.LineBotDestinationArgumentProcessor;
@@ -41,6 +44,13 @@ public class LineBotWebBeans {
         this.lineBotProperties = lineBotProperties;
     }
 
+    @Bean
+    @ConditionalOnMissingBean(SkipSignatureVerificationSupplier.class)
+    public SkipSignatureVerificationSupplier skipSignatureVerificationSupplier() {
+        final boolean skipVerification = lineBotProperties.skipSignatureVerification();
+        return FixedSkipSignatureVerificationSupplier.of(skipVerification);
+    }
+
     /**
      * Expose {@link LineSignatureValidator} as {@link Bean}.
      */
@@ -55,7 +65,8 @@ public class LineBotWebBeans {
      */
     @Bean
     public WebhookParser lineBotCallbackRequestParser(
-            LineSignatureValidator lineSignatureValidator) {
-        return new WebhookParser(lineSignatureValidator);
+            LineSignatureValidator lineSignatureValidator,
+            SkipSignatureVerificationSupplier skipSignatureVerificationSupplier) {
+        return new WebhookParser(lineSignatureValidator, skipSignatureVerificationSupplier);
     }
 }


### PR DESCRIPTION
## Changes

- Allow skipping signature verification for webhooks

## Motivation

The signature returned with webhooks is calculated using a single channel secret. If the bot owner changes their channel secret, the signature for webhooks starts being calculated using the new channel secret. To avoid signature verification failures, the bot owner must update the channel secret on their server, which is used for signature verification. However, if there is a timing mismatch in the update—and such a mismatch is almost unavoidable—verification will fail during that period.

In such cases, having an option to skip signature verification for webhooks would be a convenient way to avoid these issues.