### PR TITLE
Run all tests again

### DIFF
--- a/buildSrc/src/main/kotlin/sdk.java-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/sdk.java-library.gradle.kts
@@ -65,6 +65,7 @@ tasks.withType<Javadoc> {
 }
 
 tasks.withType(Test::class.java) {
+    useJUnitPlatform()
     testLogging {
         // Make sure output from standard out or error is shown in Gradle output.
         showStandardStreams = true

--- a/gradle/libraries.versions.toml
+++ b/gradle/libraries.versions.toml
@@ -47,7 +47,7 @@ jsonassert = { module = "org.skyscreamer:jsonassert", version = "1.5.3" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 wiremock = { group = "org.wiremock", name = "wiremock-standalone", version = "3.13.1" }
-test-arranger = { module = "com.ocadotechnology.gembus:test-arranger", version = "1.6.4.1" }
+test-arranger = { module = "com.ocadotechnology.gembus:test-arranger", version = "1.5.7.1" }
 socks-proxy-server = { module = "com.github.bbottema:java-socks-proxy-server", version = "4.1.2" }
 littleproxy = { module = "io.github.littleproxy:littleproxy", version = "2.4.3" }
 

--- a/line-bot-integration-test/build.gradle.kts
+++ b/line-bot-integration-test/build.gradle.kts
@@ -79,4 +79,5 @@ dependencies {
     integrationTestImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
     integrationTestImplementation(project(":line-bot-jackson"))
     integrationTestRuntimeOnly(libs.jjwt.impl)
+    integrationTestRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/spring-boot/line-bot-spring-boot-client/build.gradle.kts
+++ b/spring-boot/line-bot-spring-boot-client/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test") // MockHttpServletRequest
     testImplementation("org.springframework.boot:spring-boot-starter-logging")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     // http://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html#configuration-metadata-annotation-processor
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/spring-boot/line-bot-spring-boot-handler/build.gradle.kts
+++ b/spring-boot/line-bot-spring-boot-handler/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 
     testImplementation(libs.wiremock)
     testImplementation("org.springframework.boot:spring-boot-starter-test") // MockHttpServletRequest
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     // http://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html#configuration-metadata-annotation-processor
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/spring-boot/line-bot-spring-boot-web/build.gradle.kts
+++ b/spring-boot/line-bot-spring-boot-web/build.gradle.kts
@@ -33,4 +33,5 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test") // MockHttpServletRequest
     testImplementation("org.springframework.boot:spring-boot-starter-logging")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/spring-boot/line-bot-spring-boot-webmvc/build.gradle.kts
+++ b/spring-boot/line-bot-spring-boot-webmvc/build.gradle.kts
@@ -31,4 +31,5 @@ dependencies {
     testImplementation(libs.wiremock)
     testImplementation("org.springframework.boot:spring-boot-starter-test") // MockHttpServletRequest
     testImplementation("org.springframework.boot:spring-boot-starter-logging")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }


### PR DESCRIPTION
After https://github.com/line/line-bot-sdk-java/pull/1633/commits/2f6e5193a3f025fcdc5f3e3b730b22dcde0a1969 in https://github.com/line/line-bot-sdk-java/pull/1633, all tests has not been run for months. Renovate PR and other PRs are passed, because no test ran.

This change fixes the current situation.

Referance
- https://docs.gradle.org/8.14.3/userguide/upgrading_version_8.html#test_framework_implementation_dependencies (The PR should have seen this written in warn message)
- https://stackoverflow.com/questions/77579350/how-do-i-get-rid-of-automatic-loading-of-test-framework-implementation-dependen
