### PR TITLE
Fix limit object usage in sample

### DIFF
--- a/samples/sample-manage-audience/src/main/java/com/linecorp/bot/messagingapidemoapp/controller/message/NarrowcastController.java
+++ b/samples/sample-manage-audience/src/main/java/com/linecorp/bot/messagingapidemoapp/controller/message/NarrowcastController.java
@@ -144,7 +144,7 @@ public class NarrowcastController {
                 messageList,
                 recipientObject,
                 new Filter(new OperatorDemographicFilter(condition, null, null)),
-                maxLimit == null ? null : new Limit(maxLimit, false),
+                maxLimit == null ? null : new Limit.Builder().max(maxLimit).upToRemainingQuota(false).build(),
                 notificationDisabled
         );
         return messagingClient.narrowcast(null, narrowcast).thenApply(


### PR DESCRIPTION
## Changes

Refactored `Limit` initialization to use the builder pattern:

```java
new Limit.Builder().max(maxLimit).upToRemainingQuota(false).build()
```

This prevents build failures when new fields are added to the `Limit` class.
