### PR TITLE
Enable Gradle parallel build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.warning.mode=all
+org.gradle.parallel=true


### PR DESCRIPTION
GitHub Actions runners only have 2 cores, so the benefit is limited there, but local runs can benefit from parallelization.

Let’s enable this.