### PR TITLE
Update spring-boot to 4.1.0 and spotbugs-gradle-plugin to 6.5.8

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,8 +14,8 @@ dependencies {
     // plugins
     implementation("io.github.gradle-nexus:publish-plugin:2.0.0")
     implementation("org.openapitools:openapi-generator-gradle-plugin:7.23.0")
-    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.5.5")
-    implementation("org.springframework.boot:spring-boot-gradle-plugin:4.0.6")
+    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.5.8")
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:4.1.0")
 
     // workaround to use libs in a precompiled script plugin.
     // https://github.com/gradle/gradle/issues/15383

--- a/clients/line-bot-client-base/src/main/java/com/linecorp/bot/client/base/http/HttpRequestBody.java
+++ b/clients/line-bot-client-base/src/main/java/com/linecorp/bot/client/base/http/HttpRequestBody.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 import okhttp3.RequestBody;
 import okio.Buffer;
 
-public class HttpRequestBody {
+public final class HttpRequestBody {
     private final RequestBody body;
 
     public HttpRequestBody(RequestBody body) {

--- a/clients/line-bot-client-base/src/main/java/com/linecorp/bot/client/base/http/HttpResponseBody.java
+++ b/clients/line-bot-client-base/src/main/java/com/linecorp/bot/client/base/http/HttpResponseBody.java
@@ -23,7 +23,7 @@ import okhttp3.ResponseBody;
 import okio.Buffer;
 import okio.BufferedSource;
 
-public class HttpResponseBody {
+public final class HttpResponseBody {
     private final ResponseBody body;
 
     public HttpResponseBody(ResponseBody body) {

--- a/config/findbugs/excludeFilter.xml
+++ b/config/findbugs/excludeFilter.xml
@@ -48,11 +48,6 @@
     <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION" />
   </Match>
 
-  <!-- Constructors validate arguments with Objects.requireNonNull, which may throw. -->
-  <Match>
-    <Bug pattern="CT_CONSTRUCTOR_THROW" />
-  </Match>
-
   <Match>
     <Bug pattern="EI_EXPOSE_REP2" />
   </Match>

--- a/config/findbugs/excludeFilter.xml
+++ b/config/findbugs/excludeFilter.xml
@@ -48,6 +48,11 @@
     <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION" />
   </Match>
 
+  <!-- Constructors validate arguments with Objects.requireNonNull, which may throw. -->
+  <Match>
+    <Bug pattern="CT_CONSTRUCTOR_THROW" />
+  </Match>
+
   <Match>
     <Bug pattern="EI_EXPOSE_REP2" />
   </Match>

--- a/line-bot-parser/src/main/java/com/linecorp/bot/parser/WebhookParser.java
+++ b/line-bot-parser/src/main/java/com/linecorp/bot/parser/WebhookParser.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.bot.jackson.ModelObjectMapper;
 import com.linecorp.bot.webhook.model.CallbackRequest;
 
-public class WebhookParser {
+public final class WebhookParser {
     public static final String SIGNATURE_HEADER_NAME = "X-Line-Signature";
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(WebhookParser.class);
 

--- a/spring-boot/line-bot-spring-boot-client/src/test/java/com/linecorp/bot/spring/boot/core/properties/BotPropertiesValidatorTest.java
+++ b/spring-boot/line-bot-spring-boot-client/src/test/java/com/linecorp/bot/spring/boot/core/properties/BotPropertiesValidatorTest.java
@@ -19,7 +19,6 @@ package com.linecorp.bot.spring.boot.core.properties;
 import static com.linecorp.bot.spring.boot.core.properties.LineBotProperties.ChannelTokenSupplyMode.FIXED;
 import static com.linecorp.bot.spring.boot.core.properties.LineBotProperties.ChannelTokenSupplyMode.SUPPLIER;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.internal.engine.path.PathImpl.createPathFromString;
 
 import java.net.URI;
 import java.time.Duration;
@@ -79,7 +78,7 @@ public class BotPropertiesValidatorTest {
         //Verify
         assertThat(constraintViolations)
                 .isNotEmpty()
-                .filteredOn("propertyPath", createPathFromString("channelToken"))
+                .filteredOn(violation -> violation.getPropertyPath().toString().equals("channelToken"))
                 .singleElement()
                 .extracting(ConstraintViolation::getMessage)
                 .isEqualTo("channelToken is null");
@@ -104,7 +103,7 @@ public class BotPropertiesValidatorTest {
         //Verify
         assertThat(constraintViolations)
                 .isNotEmpty()
-                .filteredOn("propertyPath", createPathFromString("channelToken"))
+                .filteredOn(violation -> violation.getPropertyPath().toString().equals("channelToken"))
                 .singleElement()
                 .extracting(ConstraintViolation::getMessage)
                 .isEqualTo("channelToken should be null if channelTokenSupplyMode = SUPPLIER");


### PR DESCRIPTION
## Summary

Combines the two Renovate dependency PRs #1914 and #1912 into a single PR and resolves the CI failures both were hitting.

- **spring-boot-gradle-plugin 4.0.6 → 4.1.0** (#1914)
- **spotbugs-gradle-plugin 6.5.5 → 6.5.8** (#1912)

> [!WARNING]
> This PR contains breaking changes (three classes are now `final`) and is intended for the **next major release**.

## Why CI was failing & how it is fixed

### #1914 (spring-boot 4.1.0) — test compilation error
Spring Boot 4.1.0 upgrades Hibernate Validator to 9.x, which removed the internal API `org.hibernate.validator.internal.engine.path.PathImpl.createPathFromString`. `BotPropertiesValidatorTest` imported and called it statically, so the test source failed to compile (`symbol: method createPathFromString(String)`, 4 errors).

Fix: drop the dependency on the Hibernate Validator internal class and filter on the property path's string representation instead:

```java
.filteredOn(violation -> violation.getPropertyPath().toString().equals("channelToken"))
```

### #1912 (spotbugs 6.5.8) — `spotbugsMain` failed
spotbugs-gradle-plugin 6.5.6+ bundles SpotBugs core 4.10.x, which reports `CT_CONSTRUCTOR_THROW` for constructors that validate arguments with `Objects.requireNonNull(...)`: such a constructor can throw and leave a partially-initialized object exposed to a finalizer attack.

Across all modules this affects exactly three classes. Rather than suppress the pattern, make each class `final` so it can no longer be subclassed, which eliminates the finalizer-attack vector at its root:

- `com.linecorp.bot.parser.WebhookParser`
- `com.linecorp.bot.client.base.http.HttpRequestBody`
- `com.linecorp.bot.client.base.http.HttpResponseBody`

**BREAKING CHANGE**: the three classes above are now `final` and can no longer be extended.